### PR TITLE
Rewrite Help section for PromptQL

### DIFF
--- a/docs/help/glossary.mdx
+++ b/docs/help/glossary.mdx
@@ -19,125 +19,131 @@ seoFrontMatterUpdated: true
 
 # Hasura DDN Glossary
 
-## Hasura v3
-
-Hasura v3 represents a major version change for the main underlying component of Hasura Cloud.
-
-There are significant enhancements to the engine, including:
-
-1. A new architecture
-2. A switch to the Rust programming language
-3. A new specification to work with the engine.
-
-Because of the new specification, the engine is now decoupled from the API protocol, such as GraphQL, and as a result in
-the coming years the `graphql-engine` will evolve to become the `graphql-api-engine` and finally the `api-engine`.
-
-Apart from the enhancements to the `graphql-engine`, Hasura v3 also introduced the rollout of the new Native Data
-Connector Specification and the associated connectors.
+## PromptQL
 
 ## Hasura Data Delivery Network (DDN)
 
-Hasura DDN is a brand-new offering that is powered by the innovations in Hasura v3. While Hasura v3 data plane is open
-source, DDN represents a managed service for that data plane with the promise of operationally excellent APIs and
-replaces the application/API server infrastructure requirement for organizations.
+Hasura DDN is a managed service that powers PromptQL. It provides the infrastructure needed to connect, unify, and serve
+data from multiple sources — securely and at scale.
 
-On top of that, Hasura DDN is a globally distributed, and always available cloud for APIs and data connectivity, which
-enables blazingly-fast and secure delivery of real-time data. The new runtime engine in Hasura DDN accesses metadata on
-a per-request basis, enabling improved isolation and scalability.
+Hasura DDN delivers a production-ready platform that removes the need to manage your own API or application server. It
+handles everything under the hood so that PromptQL can focus on understanding your questions and delivering accurate,
+real-time answers.
 
-Apart from the managed data plane, DDN also includes a brand-new control plane which comprises metadata authoring,
-CI/CD, cloud infrastructure components, and collaboration features. In v2, we bundled the control plane and data plane
-together. In v3, we have separated the control plane and data plane. The control plane is closed source and commercial
-only.
+Hasura DDN is globally-distributed and always available. Its new runtime engine accesses metadata on a per-request
+basis, enabling better isolation, high scalability, and faster response times.
+
+The managed control plane includes tools for metadata authoring, CI/CD, infrastructure management, and team
+collaboration. This separation of control and data planes (unlike earlier versions, where they were bundled together)
+allows you to manage your metadata in version control and deploy confidently—so PromptQL always has the context it needs
+to reason across your data sources and respond reliably.
 
 ## Control plane
 
 The control plane manages the configuration, orchestration, and coordination of the data plane elements along with
 providing tools to author metadata. It is responsible for setting up and managing the behavior, policies, and rules that
 govern how data is processed and forwarded in the data plane. It also oversees the overall behavior of the system,
-manages the API endpoints, maintains the API configurations, handles authentication and access control mechanisms, and
-gathers analytics or metrics related to API usage.
+manages the endpoints, maintains the configurations, handles authentication and access control mechanisms, and gathers
+analytics or metrics related to application usage.
 
 ## Data Plane
 
-The data plane manages the actual handling of API requests and responses. It deals with the execution of API operations,
-the transmission of data between clients and the API endpoints, and the processing of data payloads. The following are
-the main components of a data plane:
+The data plane manages the actual handling of application requests and responses. It deals with the execution of
+application operations, the transmission of data between clients and endpoints, and the processing of data payloads. The
+following are the main components of a data plane:
 
-**Hasura v3 GraphQL Engine:** The engine takes in an API request (a GraphQL query for example), converts it into an
+**Hasura v3 GraphQL Engine:** The engine takes in an API request (e.g., a question for PromptQL), converts it into an
 intermediate representation that the connectors can handle, and creates a plan for the query execution across various
 data sources.
 
 **Hasura connectors:** These handle the actual API execution. They accept the intermediate representation from the
 engine and use the most efficient mechanism to execute the query and fetch/mutate data from the underlying data source.
 
-Both the components mentioned above are open sourced.
-
 ## Supergraph
 
-A supergraph is an architecture and operating model to build and scale multiple data domains (or subgraphs) as a single
-graph of data entities and operations.
+A supergraph is how PromptQL sees the big picture.
 
-Supergraphs help us to benefit from a centralized monolithic approach (high cohesion and easy governance) on a federated
-microservices execution model (loose coupling and scaling ownership).
+It connects multiple subgraphs - each representing a specific data domain - into a single graph that PromptQL can query
+across. This lets you organize your data by team or domain, without giving up the ability to ask questions that span
+everything.
 
-Today, supergraphs are more critical than ever because accelerating data and microservice sprawl are making the
-complexity of data and API consumption untenable – showing up in slower time-to-market, harder to address tech-debt and
-complex team communication. [Learn more](https://hasura.io/supergraph).
+The supergraph balances the benefits of modular development (independent teams, separate repositories, clear ownership)
+with a unified interface for querying. It keeps everything loosely coupled under the hood, but tightly integrated when
+you need answers.
+
+PromptQL uses the supergraph to reason across connected domains and return accurate results - even when the data lives
+in different systems or is owned by different teams.
+
+[Learn more](https://hasura.io/supergraph).
 
 ## Subgraphs
 
-A subgraph represents a self-contained module of metadata and its accompanying data connector(s) which encapsulates a
-specific data domain. Subgraphs have a permission model, and an independent software development life cycle, and can be
-developed, tested, and built independently. The supergraph guarantees the integrity of subgraph composition.
+A subgraph is a building block of the supergraph - and the unit PromptQL uses to understand each part of your data.
 
-Subgraphs can be managed in their own isolated repositories and built completely independently of each other. Fields
-exposed to the full supergraph can be prefixed to prevent schema conflicts. Data can be interlinked between subgraphs
-using relationships, even between subgraphs in separate repositories.
+Each subgraph is a standalone module that includes metadata, permissions, and one or more data connectors. It defines a
+clear boundary around a specific data domain, like users, orders, or content. Subgraphs are independently developed,
+tested, and versioned - so teams can work in parallel without stepping on each other.
 
-A subgraph is analogous to a microservice owned by a particular team.
+Fields in a subgraph can be scoped or prefixed to avoid conflicts. Relationships between subgraphs let PromptQL follow
+connections across domains when answering questions.
 
 ## Globals subgraph
 
-When running the `ddn supergraph init` command, a `globals` subgraph is created by default for your convenience. This
-subgraph is intended to hold global configuration objects for the supergraph, such as API configuration and auth
-settings.
+When you run the `ddn supergraph init` command, a `globals` subgraph is created by default.
 
-These configuration objects are `AuthConfig`, `CompatibilityConfig` and `GraphqlConfig` as well as the `subgraph.yaml`
-configuration file which defines the globals subgraph itself.
+This subgraph holds shared configuration that applies across your entire supergraph - things like API settings, auth
+rules, and compatibility options. It gives PromptQL the context it needs to understand how to route, secure, and execute
+your conversations correctly.
 
-These objects are located by default in the `globals` subgraph, but can be moved to any other subgraph if needed.
+By default, these objects live in the `globals` subgraph, but you can move them to another subgraph if needed.
 
-## Hasura Metadata
+## Hasura metadata
 
-Hasura metadata models a supergraph and specifies the API for the supergraph. It is the configuration that is provided
-declaratively to help connect to the data source and provide a working API. It introduces key supergraph modeling
-constructs such as `Types`, `Models`, `Commands`, `Permissions`, and `Relationships`, which help in understanding and
-implementing systems that align closely with the real-world domain they are meant to represent. Apart from modeling
-constructs, the metadata also defines key configuration around API security, caching, deployment, and CI/CD, that helps
-explain the entire API system for the organization. [Learn more](/reference/metadata-reference/index.mdx).
+Hasura metadata defines the structure of your supergraph; it gives PromptQL the context it needs to ask the right
+questions, enforce permissions, and return meaningful answers.
+
+Metadata is written declaratively and describes how to connect to your data sources, what the API should look like, and
+how different parts of your system relate to each other. It introduces key modeling constructs such as `Types`,
+`Models`, `Commands`, `Permissions`, and `Relationships` to represent your real-world domain in a way PromptQL can
+understand.
+
+Beyond that, metadata also includes configuration for API security, caching, CI/CD, and deployment - giving your team
+full control over how the application behaves.
+
+[Learn more](/reference/metadata-reference/index.mdx).
 
 ## .hml (Hasura Metadata Language)
 
-The file extension for the files that conform to the Hasura metadata specification for the supergraph. It is a
-derivative of `.yaml` extension (and shares the same syntax) and provides the same benefits such as 1) readability, 2)
-data structures, 3) comments, and 4) portability, to author, reason, and share metadata.
+`.hml` is the file extension used for writing Hasura metadata. It shares the same syntax as `.yaml`, and offers the same
+benefits: it's readable, supports nested data structures, allows for inline comments, and is portable across
+environments and teams.
+
+PromptQL relies on `.hml` files to understand how your data is structured and how it can be queried and secured.
 
 ## Supergraph modeling
 
-The act of writing information to conform to the Hasura metadata specification and the process of identifying, defining,
-and structuring the distinct sets of the supergraph elements or attributes.
+Supergraph modeling is the process of defining how your data, operations, and relationships are represented in metadata.
 
-## Immutable-Build Runtime System
+By identifying and structuring the elements of your system - like types, models, permissions, and relationships - you
+create a clear, declarative blueprint. PromptQL uses this blueprint to answer questions, enforce rules, and coordinate
+across connected data sources.
 
-The new runtime engine in Hasura DDN, which accesses metadata on a per-request basis, enables improved isolation and
-scalability. This independent build system allows a runtime that eliminates shared state and cold start issues for
-enhanced performance.
+## Immutable-Build runtime system
+
+Hasura DDN uses an immutable build system for your metadata. Each time you make a change, a new build is created. This
+means PromptQL always runs against a specific, versioned snapshot of your supergraph.
+
+There’s no shared state to manage, no long-running config to refresh. Every request is served using a clean, isolated
+runtime - making rollbacks, previews, and CI/CD workflows straightforward and reliable.
+
+You can confidently ship changes to your API, knowing PromptQL will always use the exact version you deployed - and if
+something goes wrong, you can roll back just as easily.
 
 ## Data Sources
 
-Any external data source, database, or service that can be connected to Hasura DDN using a Data Connector agent. Every
-data source must have connector URL and schema. [Learn more](/reference/metadata-reference/data-connector-links.mdx).
+Any external data source, database, or service that can be connected to Hasura DDN using a Data Connector agent.
+
+[Learn more](/reference/metadata-reference/data-connector-links.mdx).
 
 ## Native Data Connector Specification (NDC Spec)
 
@@ -146,6 +152,7 @@ that resolve new sources of data and business logic and help define the metadata
 specification defines types such as `collections`, `functions`, and `procedures` that help in describing the behavior of
 agents or connectors that connect to the underlying data source. It provides a framework and guidelines on the types of
 web service endpoints that a connector needs to implement.
+
 [Learn more](/reference/metadata-reference/data-connector-links.mdx).
 
 ## Native Data Connectors
@@ -160,7 +167,9 @@ separate connector instances - allowing teams to work with the same source from 
 
 Data connectors are available for a wide variety of sources including databases, business logic functions, REST APIs,
 and GraphQL APIs. They can be official Hasura-verified connectors or custom-built connectors to integrate with other
-data sources. [Learn more](/data-sources/overview.mdx).
+data sources.
+
+[Learn more](/data-sources/overview.mdx).
 
 ## Push-Down Capabilities
 
@@ -172,39 +181,48 @@ This can improve query optimization and performance and is the reason why data c
 
 Refers to the public site where all Native Data Connectors for Hasura DDN are listed. Users can discover connectors, get
 more information about their specific features and find documentation on how to use each connector with Hasura DDN.
+
 [Learn more](https://hasura.io/connectors/).
 
 ## Model
 
-A metadata object that is fundamental to API design in Hasura DDN. The model is the entity that has a direct mapping to
-the underlying native data connector object or collection.
+A model defines an entity in your API that maps directly to something in your underlying data source - like a table,
+collection, or resource exposed by a native data connector.
 
-A model includes reference to the data type and includes configuration details related to API configuration, arguments
-and global ids.
+Models are central to how PromptQL understands your data. Each model includes a reference to its data type, API
+configuration, available arguments, and optional global ID settings. Models support select, insert, update, and delete
+operations.
 
-It supports select, insert, update and delete operations. Within the select operation the different query operations
-include filtering, aggregating, paginating and limiting. [Learn more](/reference/metadata-reference/models.mdx).
+Within a select operation, PromptQL can handle filtering, aggregation, pagination, and limiting - giving you full
+flexibility when asking questions.
+
+[Learn more](/reference/metadata-reference/models.mdx)
 
 ## Command
 
-The Hasura entity that helps encapsulate business logic and represents an action that can be performed which returns
-back some type of result. It directly maps to the native data connector object's functions and procedures.
-[Learn more](/reference/metadata-reference/commands.mdx).
+A command defines a piece of business logic that PromptQL can call as an action. It represents something you can do - a
+procedure, mutation, or custom operation - and returns a result.
+
+Commands map directly to functions or procedures defined in your connected data sources. PromptQL uses commands when you
+want to go beyond querying and take meaningful action.
+
+[Learn more](/reference/metadata-reference/commands.mdx)
 
 ## Relationships
 
-A metadata object in Hasura DDN that defines the relationship between two models or between a model and a command.
+A relationship connects two models - or a model and a command - and tells PromptQL how different pieces of your data are
+linked.
 
-Defining a [relationship](/reference/metadata-reference/relationships.mdx) allows you to make queries across linked
-information within and between subgraphs.
+With relationships in place, PromptQL can traverse from one part of your system to another, combining data as it answers
+questions. Relationships can be defined within a single subgraph or across subgraphs - even if those subgraphs live in
+different repositories.
 
-When working with relationships across subgraphs in other repositories, there are some differences to be aware of. Find
-out more about cross-repo relationships
+When working across subgraphs, there are a few structural differences to keep in mind. You can read more about those
 [here](project-configuration/subgraphs/working-with-multiple-subgraphs.mdx#cross-repo-relationships).
 
-As always when authoring metadata, the
-[Hasura VS Code extension](https://marketplace.visualstudio.com/items?itemName=HasuraHQ.hasura) can assist with
-auto-complete and validation.
+To make working with relationships easier, the
+[Hasura VS Code extension](https://marketplace.visualstudio.com/items?itemName=HasuraHQ.hasura) offers auto-complete and
+validation as you author metadata.
 
 ## Authorization Permissions
 
@@ -219,13 +237,6 @@ their respective subgraphs, and do not affect other subgraphs.
 Authorization rules in one subgraph can also be defined to reference data in a foreign subgraph even if that subgraph is
 in another repository.
 
-## Global ID
-
-Refers to the Relay global ID that encodes the type and ID of an object in a single string. In Hasura this is defined
-per model and enables fetching any object directly, regardless of what kind of object it is. A result of this is that
-you get the node root field in the GraphQL API schema to use with a Relay client.
-[Learn more](/reference/metadata-reference/models.mdx).
-
 ## Collection
 
 A collection is a Native Data Connector Spec object, which encapsulates part of a data source, providing standard
@@ -235,6 +246,7 @@ Each collection is defined by its name, any collection arguments (need to parame
 (a collection of fields) of its rows, and some additional metadata related to constraints.
 
 Tracking a collection results in the creation of a 'model' object in Hasura metadata.
+
 [Learn more](https://hasura.github.io/ndc-spec/specification/schema/collections.html).
 
 ## Function
@@ -244,6 +256,7 @@ doesn't have side-effects and is thus "read only". Unlike collections, functions
 have object types.
 
 Tracking a function results in the creation of a `Command` Supergraph object in Hasura metadata.
+
 [Learn more](https://hasura.github.io/ndc-spec/specification/schema/functions.html).
 
 ## Procedure
@@ -252,28 +265,29 @@ A procedure is a native data connector specification object, and it defines an a
 and can mutate data and have other side-effects. Each procedure has arguments and a return type.
 
 Tracking a procedure results in the creation of a `Command` object in Hasura metadata.
+
 [Learn more](https://hasura.github.io/ndc-spec/specification/schema/procedures.html).
-
-## Builds
-
-Each metadata change in Hasura DDN represents an immutable build. Every build has a unique GraphQL Endpoint that can be
-tested independently. Builds exist in in projects and there is a one-to-many mapping between projects and builds. [Learn
-more](/project/configuration/overview.mdx
 
 ## Supergraph config
 
 Supergraph config tells Hasura DDN how to construct your supergraph. A config will contain information such as which
-subgraphs to include and which resources to use for the build. [Learn more](/project/configuration/overview.mdx
+subgraphs to include and which resources to use for the build.
+
+[Learn more](/project-configuration/overview.mdx).
 
 ## Connector config
 
 Connector config tells Hasura DDN how to build your connector. It will contain information such as the type of connector
-and the location to the context files needed to build the connector. [Learn more](/project/configuration/overview.mdx
+and the location to the context files needed to build the connector.
+
+[Learn more](/project-configuration/overview.mdx).
 
 ## DDN CLI (Command-Line Interface)
 
 A tool in Hasura DDN that enables developers to interact with DDN from the command line. It supports various commands
-for creating builds, tracking objects, and deploying projects. [Learn more](/reference/cli/index.mdx).
+for creating builds, tracking objects, and deploying projects.
+
+[Learn more](/reference/cli/index.mdx).
 
 ## VS Code Extension
 
@@ -284,25 +298,28 @@ go-to-definition for inter-related DDN metadata objects, documentation on hover 
 tree on sidebar which shows all DDN projects and metadata objects present in the currently opened folder.
 
 It is strongly recommended to download the VS code extension while working with DDN projects, it can be downloaded from
-[VS Code extension marketplace](https://marketplace.visualstudio.com/items?itemName=HasuraHQ.hasura).
+the [VS Code extension marketplace](https://marketplace.visualstudio.com/items?itemName=HasuraHQ.hasura).
 
 ## Metadata build service
 
-Creates builds from the metadata and makes it available to Hasura v3 GraphQL Engine at the edge for it to serve the API
-request. Provides essential error handling for fast debugging and troubleshooting.
+Creates builds from the metadata and makes it available to Hasura v3 GraphQL Engine at the edge for it to serve the
+application. Provides essential error handling for fast debugging and troubleshooting.
 
 ## Control plane cloud API
 
 This component is the underlying cloud service, which enables creating builds, applying builds and testing your API. We
 consider this the brain of DDN Console and CLI – the component that drives most of the DX functionalities.
 
-## DDN Console
+## PromptQL Console and Playground
 
-An interface in Hasura DDN that provides tools for metadata visualizing, API testing and deployment, team collaboration,
-documentation, traces, and analytics.
+An interface in Hasura DDN that provides tools for metadata visualizing, team collaboration, documentation, traces, and
+analytics.
+
+Additionally, the Playground is your primary method of interacting with and testing conversations before integrating the
+PromptQL API into your customer-facing application(s).
 
 ## Cloud PAT
 
 This refers to a personal authentication token that Hasura Cloud creates automatically for you on every new project
-creation. This ensures that your GraphQL API always has a security mechanism. The auto-generated PAT is included in the
+creation. This ensures that your application always has a security mechanism. The auto-generated PAT is included in the
 API header `cloud_pat`.

--- a/docs/help/overview.mdx
+++ b/docs/help/overview.mdx
@@ -26,17 +26,11 @@ data source. Once you're comfortable, expand your knowledge with sections like
 [data sources](data-sources/overview.mdx), [data modeling](data-modeling/overview.mdx), [auth](auth/overview.mdx),
 [observability](observability/overview.mdx), and [deployment](deployment/overview.mdx).
 
-### Ask the DocsBot
-
-Need additional guidance? The DocsBot, powered by OpenAI's GPT-4o model, is here to help! Click the "Docs Assistant"
-button in the header to get tailored answers directly from our documentation.
-
 ### Ask the community
 
-- We have a Discord server where you can ask questions and get help from the community and Hasura champions.
-  [Join here](https://discord.com/invite/hasura).
+- We have a forum where you can ask questions and get help from the community and Hasura employees. [Join here](#).
 - Additionally, you can create a GitHub issue for any bugs or feature requests
-  [here](https://github.com/hasura/graphql-engine/issues).
+  [here](https://github.com/hasura/promptql/issues).
 
 ## Enterprise clients
 

--- a/docs/help/security.mdx
+++ b/docs/help/security.mdx
@@ -191,8 +191,9 @@ definition:
 
 ## Native Operations and Security
 
-Hasura DDN allows you to extend the GraphQL API using native queries and mutations, providing direct access to the
-underlying data source's capabilities. However, this comes with the responsibility of preventing vulnerabilities.
+Hasura DDN allows you to extend your application's capabilities using native queries and mutations, providing direct
+access to the underlying data source's capabilities. However, this comes with the responsibility of preventing
+vulnerabilities.
 
 **Important Considerations:**
 


### PR DESCRIPTION
## Description 📝

Rewrites Help section for PromptQL.

One question that needs to be addressed: Here, we're still referring to the v3 engine (especially in the policies and versioning sections). Is this piece of the stack still relevant? Conventional wisdom says, 'yes', but we need to confirm this.