### PR TITLE
Updated the number of credits, and text based on PromptQL GTM

### DIFF
--- a/docs/promptql-apis/natural-language-api.mdx
+++ b/docs/promptql-apis/natural-language-api.mdx
@@ -94,7 +94,7 @@ The `llm` and `ai_primitives_llm` fields support the following providers:
 
 :::info Free credits
 
-You get $10 worth of free credits with Hasura's built-in provider when you get started.
+You get $20 worth of free credits with Hasura's built-in provider during our trial. You can [reach out to us](https://hasura.io/contact-us) to add more credits.
 
 :::
 

--- a/docs/promptql-apis/natural-language-api.mdx
+++ b/docs/promptql-apis/natural-language-api.mdx
@@ -94,7 +94,7 @@ The `llm` and `ai_primitives_llm` fields support the following providers:
 
 :::info Free credits
 
-You get $20 worth of free credits with Hasura's built-in provider during our trial. You can [reach out to us](https://hasura.io/contact-us) to add more credits.
+You get $20 worth of free credits with Hasura's built-in provider during the trial. You can [reach out to us](https://hasura.io/contact-us) to add more credits.
 
 :::
 

--- a/docs/promptql-apis/natural-language-api.mdx
+++ b/docs/promptql-apis/natural-language-api.mdx
@@ -94,7 +94,8 @@ The `llm` and `ai_primitives_llm` fields support the following providers:
 
 :::info Free credits
 
-You get $20 worth of free credits with Hasura's built-in provider during the trial. You can [reach out to us](https://hasura.io/contact-us) to add more credits.
+You get $20 worth of free credits with Hasura's built-in provider during the trial.
+[Reach out to us](https://hasura.io/contact-us) to add more credits.
 
 :::
 

--- a/docs/promptql-playground/public-projects.mdx
+++ b/docs/promptql-playground/public-projects.mdx
@@ -73,7 +73,8 @@ public PromptQL project.
 
 :::info Token Usage and Billing
 
-By default, token usage for public projects will be billed from the user's PromptQL credits. Project owners have the option to configure a custom LLM if they prefer to handle the token usage differently.
-PromptQL includes promotional credits during the 30-day trial period. After the trial period ends, you'll need to [contact our sales team](https://hasura.io/contact-us) to learn more about pricing options.
+Token usage in public projects is charged to your PromptQL credits by default. However, project owners can set up a custom LLM provider to manage token usage according to their preferences. During your 30-day trial period, you'll receive complimentary promotional credits to get started.
+
+When your trial period expires, [reach out to our sales team](https://hasura.io/contact-us) to discuss available pricing plans and options.
 
 :::

--- a/docs/promptql-playground/public-projects.mdx
+++ b/docs/promptql-playground/public-projects.mdx
@@ -73,7 +73,7 @@ public PromptQL project.
 
 :::info Token Usage and Billing
 
-By default, token usage for public projects will be billed from the user's PromptQL credits. Project owners have the
-option to configure a custom LLM if they prefer to handle the token usage differently.
+By default, token usage for public projects will be billed from the user's PromptQL credits. Project owners have the option to configure a custom LLM if they prefer to handle the token usage differently.
+PromptQL includes promotional credits during the 30-day trial period. After the trial period ends, you'll need to [contact our sales team](https://hasura.io/contact-us) to learn more about pricing options.
 
 :::

--- a/docs/promptql-playground/public-projects.mdx
+++ b/docs/promptql-playground/public-projects.mdx
@@ -73,8 +73,11 @@ public PromptQL project.
 
 :::info Token Usage and Billing
 
-Token usage in public projects is charged to your PromptQL credits by default. However, project owners can set up a custom LLM provider to manage token usage according to their preferences. During your 30-day trial period, you'll receive complimentary promotional credits to get started.
+Token usage in public projects is charged to your PromptQL credits by default. However, project owners can set up a
+custom LLM to manage token usage according to their preferences. During your 30-day trial period, you'll receive
+complimentary promotional credits to get started.
 
-When your trial period expires, [reach out to our sales team](https://hasura.io/contact-us) to discuss available pricing plans and options.
+When your trial period expires, [reach out to our sales team](https://hasura.io/contact-us) to discuss available pricing
+plans and options.
 
 :::


### PR DESCRIPTION
We recently updated the number of credits to $20 ( [commit](https://github.com/hasura/promptql-cloud/pull/261) )

Also - we need to nudge the users to talk to sales to upgrade their trials.