### PR TITLE
Improve information for APIs

### DIFF
--- a/docs/promptql-apis/auth.mdx
+++ b/docs/promptql-apis/auth.mdx
@@ -30,7 +30,7 @@ These endpoints accept all DDN-compatible authentication strategies; learn more 
   "ddn": {
     "url": "https://<PROJECT_NAME>.ddn.hasura.app/v1/sql",
     "headers": {
-      "x-hasura-ddn-token": "<YOUR_DDN_TOKEN_FROM_THE_PLAYGROUND>"
+      "x-hasura-ddn-token": "<YOUR_DDN_AUTH_TOKEN_FROM_THE_PLAYGROUND>"
     }
   },
   "artifacts": []

--- a/docs/promptql-apis/auth.mdx
+++ b/docs/promptql-apis/auth.mdx
@@ -1,0 +1,64 @@
+---
+sidebar_position: 4
+sidebar_label: Authentication in APIs
+description: ""
+keywords:
+  - hasura ddn
+  - apis
+  - auth
+---
+
+# Authentication in APIs
+
+## Introduction
+
+PromptQL endpoints accept a `ddn` object which contains details like your project's URL and what headers to pass along.
+These endpoints accept all DDN-compatible authentication strategies; learn more about these in our
+[auth docs](/auth/overview.mdx).
+
+## Modes
+
+### Default
+
+```json {10} title="By default, you can use the short-lived x-hasura-ddn-token to make requests against the Execute Program API:"
+{
+  "code": "# Get Saving Private Ryan's details\nsql = \"\"\"\nSELECT series_title, overview, genre, director, imdb_rating, released_year\nFROM app.movies\nWHERE LOWER(series_title) = 'saving private ryan'\n\"\"\"\nmovie = executor.run_sql(sql)\n\nif len(movie) == 0:\n    executor.print(\"Movie not found\")\nelse:\n    movie = movie[0]\n    # Prepare text for classification\n    classification_text = f\"\"\"\nMovie: {movie['series_title']}\nOverview: {movie['overview']}\n\"\"\"",
+  "promptql_api_key": "<YOUR_API_KEY>",
+  "ai_primitives_llm": {
+    "provider": "hasura"
+  },
+  "ddn": {
+    "url": "https://<PROJECT_NAME>.ddn.hasura.app/v1/sql",
+    "headers": {
+      "x-hasura-ddn-token": "<YOUR_DDN_TOKEN_FROM_THE_PLAYGROUND>"
+    }
+  },
+  "artifacts": []
+}
+```
+
+### JWT & Webhook Mode
+
+```json {10} title="If you're using JWT or Webhook Mode, you'll pass your authentication header:"
+{
+  "code": "# Get Saving Private Ryan's details\nsql = \"\"\"\nSELECT series_title, overview, genre, director, imdb_rating, released_year\nFROM app.movies\nWHERE LOWER(series_title) = 'saving private ryan'\n\"\"\"\nmovie = executor.run_sql(sql)\n\nif len(movie) == 0:\n    executor.print(\"Movie not found\")\nelse:\n    movie = movie[0]\n    # Prepare text for classification\n    classification_text = f\"\"\"\nMovie: {movie['series_title']}\nOverview: {movie['overview']}\n\"\"\"",
+  "promptql_api_key": "<YOUR_API_KEY>",
+  "ai_primitives_llm": {
+    "provider": "hasura"
+  },
+  "ddn": {
+    "url": "https://<PROJECT_NAME>.ddn.hasura.app/v1/sql",
+    "headers": {
+      "authorization": "Bearer <YOUR_TOKEN>"
+    }
+  },
+  "artifacts": []
+}
+```
+
+:::info Authorization Strategies
+
+The example above uses the Bearer strategy for the `tokenLocation`. Your setup may be different; consult our
+[auth docs](/auth/overview.mdx) for more information about setting up an authentication mode.
+
+:::

--- a/docs/promptql-apis/execute-program-api.mdx
+++ b/docs/promptql-apis/execute-program-api.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 3
 sidebar_label: Execute Program API
-description: ""
+description: "Learn how the Exceute Program API accepts a request and executes atomic programs using your data."
 keywords:
   - hasura ddn
   - execute program
@@ -115,13 +115,13 @@ Content-Type: application/json
 
 ```json
 {
-  "code": "<your promptql program code>",
-  "promptql_api_key": "<promptql api key created from project settings>",
+  "code": "<YOUR_PROMPTQL_GENERATED_CODE_HERE>",
+  "promptql_api_key": "<YOUR_API_KEY_HERE>",
   "ai_primitives_llm": {
     "provider": "hasura"
   },
   "ddn": {
-    "url": "<project sql endpoint url>",
+    "url": "https://<PROJECT_NAME>.ddn.hasura.app/v1/sql",
     "headers": {}
   },
   "artifacts": []
@@ -202,7 +202,7 @@ The `artifacts` array can contain both text and table artifacts:
 #### Request DDN Auth
 
 The `ddn.headers` field can be used to pass any auth header information through to DDN. Read more about
-[auth for DDN](/auth/overview.mdx).
+[auth with these APIs](/promptql-apis/auth.mdx).
 
 ### Response
 
@@ -290,7 +290,8 @@ When the API encounters an error, it will return a 422 status code with a valida
 
 ## Get PromptQL programs from the playground
 
-You can get PromptQL programs from PromptQL playground interactions by clicking on the "Export as API" button next to
-the Query Plan in the playground.
+You don't have to write these programs yourself! You can get PromptQL programs from Playground interactions by clicking
+on the "Export as API" button next to the Query Plan. Then, you can use the exported program in the `code` key-value
+pair in your request to the `/execute_program` endpoint.
 
 <Thumbnail src="/img/get-started/export-as-api.png" alt="Export as API" />

--- a/docs/promptql-apis/natural-language-api.mdx
+++ b/docs/promptql-apis/natural-language-api.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 2
 sidebar_label: Natural Language API
-description: ""
+description: "Learn how the Natural Language API accepts a request and allows you to chat with your data in realtime."
 keywords:
   - hasura ddn
   - natural language
@@ -11,9 +11,59 @@ toc_max_heading_level: 4
 
 # Natural Language API
 
+## Introduction
+
 The Natural Language Query API allows you to interact with PromptQL directly, sending messages and receiving responses
 with support for streaming. This API is particularly useful for building interactive applications that need to
 communicate with PromptQL in real-time.
+
+```json title="Example request using our quickstart:"
+{
+  "version": "v1",
+  "promptql_api_key": "<YOUR_API_KEY_HERE>",
+  "llm": {
+    "provider": "hasura"
+  },
+  "ddn": {
+    "url": "https://<PROJECT_NAME>.ddn.hasura.app/v1/sql",
+    "headers": {}
+  },
+  "artifacts": [],
+  "system_instructions": "Responde solo en espanol, por favor",
+  "timezone": "America/Los_Angeles",
+  "interactions": [
+    {
+      "user_message": {
+        "text": "What can you do?"
+      },
+      "assistant_actions": []
+    }
+  ],
+  "stream": false
+}
+```
+
+<details>
+  <summary>
+    Click here to see a sample response ☝️
+  </summary>
+
+```json title="Example response using our quickstart:"
+{
+  "assistant_actions": [
+    {
+      "message": "¡Hola! Soy un asistente que puede ayudarte con varias tareas relacionadas con películas. Específicamente, puedo:\n\n1. Buscar y analizar películas de la base de datos basado en diferentes criterios como:\n   - Título\n   - Director\n   - Año de lanzamiento\n   - Género\n   - Calificación IMDB\n   - Actores\n   - Y más\n\n2. Ayudarte a rentar películas a través del servicio Promptflix\n\n3. Crear análisis y resúmenes personalizados de películas\n\n4. Responder preguntas sobre películas específicas o tendencias generales\n\n¿Hay algo específico sobre películas que te gustaría explorar?",
+      "plan": null,
+      "code": null,
+      "code_output": null,
+      "code_error": null
+    }
+  ],
+  "modified_artifacts": []
+}
+```
+
+</details>
 
 ## Query Endpoint
 
@@ -34,12 +84,12 @@ Content-Type: application/json
 ```json
 {
   "version": "v1",
-  "promptql_api_key": "<promptql api key created from project settings>",
+  "promptql_api_key": "<YOUR_API_KEY_HERE>",
   "llm": {
     "provider": "hasura"
   },
   "ddn": {
-    "url": "<project sql endpoint url>",
+    "url": "https://<PROJECT_NAME>.ddn.hasura.app/v1/sql",
     "headers": {}
   },
   "artifacts": [],
@@ -120,7 +170,7 @@ You get $20 worth of free credits with Hasura's built-in provider during the tri
 #### Request DDN Auth
 
 The `ddn.headers` field can be used to pass any auth header information through to DDN. Read more about
-[auth for DDN](/auth/overview.mdx).
+[auth with these APIs](/promptql-apis/auth.mdx).
 
 ### Response
 
@@ -218,7 +268,8 @@ data: {
 3. **Timezone Handling**
 
    - Always provide a timezone to ensure consistent handling of time-based queries
-   - Use standard IANA timezone formats (e.g., "America/Los_Angeles", "Europe/London")
+   - Use standard [IANA timezone formats](https://www.iana.org/time-zones) (e.g., "America/Los_Angeles",
+     "Europe/London")
 
 4. **Error Handling**
    - Always check for error responses, especially in streaming mode

--- a/docs/promptql-apis/overview.mdx
+++ b/docs/promptql-apis/overview.mdx
@@ -14,10 +14,9 @@ import Thumbnail from "@site/src/components/Thumbnail";
 
 ## Introduction
 
-Typically, you'll interact with a PromptQL application via PromptQL Playground — our built-in GUI — but, PromptQL APIs
-let you embed AI-native features — like natural language querying and intelligent program execution — directly into your
-app, powered by Hasura DDN. Whether you're building chat-based experiences or running exported PromptQL programs, these
-flexible endpoints make it easy to create interactive, dynamic, and intelligent data flows.
+End users can interact with a PromptQL application via the PromptQL Playground—our built-in GUI—but, PromptQL APIs let
+you embed AI-native features—like natural language querying and intelligent program execution—directly into your app,
+powered by Hasura DDN.
 
 ## Available APIs
 


### PR DESCRIPTION
## Description 📝

Improves information for APIs by adding examples for requests and responses and by introducing an explicit section for authentication when using PromptQL.

## Quick Links 🚀

[API Overview](https://robdominguez-doc-2685-add-in.promptql-docs.pages.dev/promptql-apis/overview/)

## Assertion Tests 🤖

<!-- Add assertions between the comments below to have ChatGPT check the quality of your docs contribution (Diff) and 
how well it integrates with existing docs. E.g., A user should be able to easily understand how to make a simple 
query. -->

<!-- For more info, see the Action's docs in the marketplace: https://github.com/marketplace/actions/docs-assertion-tester#usage -->

<!-- DX:Assertion-start -->
A user should understand the shape of requests and responses from these endpoints and how to utilize their auth mechanism of choice via DDN.
<!-- DX:Assertion-end -->