### PR TITLE
Add response-size limitations for lambdas

### DIFF
--- a/docs/business-logic/errors.mdx
+++ b/docs/business-logic/errors.mdx
@@ -195,3 +195,9 @@ accurate interactions with your data over time.
 Traces — complete with your custom error messages — are available for each request. You can find these in the `Insights`
 tab of your project's console. These traces help you understand how PromptQL is interacting with your data and where
 improvements can be made to enhance accuracy.
+
+### Response-size limitations
+
+#### `hasura/nodejs` connector
+
+The `hasura/nodejs` connector has a request body limit of `30`MB.

--- a/docs/business-logic/errors.mdx
+++ b/docs/business-logic/errors.mdx
@@ -198,6 +198,11 @@ improvements can be made to enhance accuracy.
 
 ### Response-size limitations
 
-#### `hasura/nodejs` connector
+Lambda connectors have a response-size limit, which may vary depending on the SDK and should be considered when
+developing your application's business logic functions.
 
-The `hasura/nodejs` connector has a request body limit of `30`MB.
+| Connector       | Limit   | Configurable |
+| --------------- | ------- | ------------ |
+| `hasura/nodejs` | `30` MB | false        |
+| `hasura/python` | `30` MB | false        |
+| `hasura/go`     | `30` MB | false        |


### PR DESCRIPTION
## Description 📝

Adds a response-size limitations section for lambdas. Currently, the nodejs connector is the only one included here; it was easily discoverable in the underlying TS SDK. However, I'm not sure about the Python and Go SDKs...I've reached out to Toan for more information.

EDIT: ☝️ The others will follow the TS implementation.

## Quick Links 🚀

[New section](https://robdominguez-doc-2773-docume.promptql-docs.pages.dev/business-logic/errors/#response-size-limitations)