### PR TITLE
Sean Theme tweaks => Merging to robs theme => Merging to blitz

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -22,5 +22,11 @@
         "parser": "graphql"
       }
     }
+    {
+      "files": "*.css",
+      "options": {
+        "printWidth": 80
+      }
+    }
   ]
 }

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -134,10 +134,11 @@ const config: Config = {
       disableSwitch: false,
       respectPrefersColorScheme: true,
     },
-    sidebar: {
-      hideable: true,
+    docs: {
+      sidebar: {
+        hideable: true,
+      },
     },
-
     // Replace with your project's social card
     image: 'img/og-social-card.jpg',
     algolia: {
@@ -177,28 +178,28 @@ const config: Config = {
         },
       ],
     },
-
     prism: {
       theme: prismThemes.dracula,
       additionalLanguages: ['json', 'typescript', 'bash', 'yaml'],
     },
-    stylesheets: [
-      {
-        href: 'https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap',
-        rel: 'stylesheet',
-      },
-      {
-        href: 'https://fonts.googleapis.com/css2?family=Archivo:wght@500;600;700&display=swap',
-        rel: 'stylesheet',
-      },
-      {
-        href: 'https://cdn.jsdelivr.net/npm/katex@0.13.24/dist/katex.min.css',
-        type: 'text/css',
-        integrity: 'sha384-odtC+0UGzzFL/6PNoE8rX/SPcQDXBJ+uRepguP4QkPCm2LBxH3FA3y+fKSiJ+AmM',
-        crossorigin: 'anonymous',
-      },
-    ],
+    
   } satisfies Preset.ThemeConfig,
+  stylesheets: [
+    {
+      href: 'https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap',
+      rel: 'stylesheet',
+    },
+    {
+      href: 'https://fonts.googleapis.com/css2?family=Archivo:ital,wght@0,100..900;1,100..900&family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap',
+      rel: 'stylesheet',
+    },
+    {
+      href: 'https://cdn.jsdelivr.net/npm/katex@0.13.24/dist/katex.min.css',
+      type: 'text/css',
+      integrity: 'sha384-odtC+0UGzzFL/6PNoE8rX/SPcQDXBJ+uRepguP4QkPCm2LBxH3FA3y+fKSiJ+AmM',
+      crossorigin: 'anonymous',
+    },
+  ],
   markdown: {
     mermaid: true,
   },

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -214,38 +214,42 @@ html[data-theme='dark'] {
   background-color: var(--heatmap-error-red);
 }
 
-/* -------------- TYPOGRAPHY SIZES -------------- */
+/* -------------- TYPOGRAPHY & SIZES & WEIGHTS -------------- */
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: 'Archivo', sans-serif;
+  font-weight: 500;
+}
 
 h1 {
-  font-size: 1.75rem;
-  font-weight: bold;
+  font-size: 3rem;
 }
 
 h2 {
-  font-weight: bold;
-  font-size: 1.5rem;
+  font-size: 2rem;
 }
 
 h3 {
-  font-weight: bold;
-  font-size: 1.25rem;
+  font-size: 1.75rem;
 }
 
 h4 {
-  font-weight: bold;
   margin-bottom: 1rem;
-  font-size: 1.125rem;
+  font-size: 1.5rem;
 }
 
 h5 {
-  font-weight: bold;
-  font-size: 1rem;
+  font-size: 1.25rem;
 }
 
 h6 {
-  font-weight: bold;
   text-transform: uppercase;
-  font-size: 0.75rem;
+  font-size: 1.125rem;
 }
 
 p,

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1741,28 +1741,3 @@ pre[class*='language-'] code span.token {
 .sidebar-icon svg rect {
   transition: stroke 0.2s;
 }
-
-/* Style for icons in menu items on hover */
-.menu__link:hover .sidebar-icon svg path,
-.menu__link:hover .sidebar-icon svg line,
-.menu__link:hover .sidebar-icon svg circle,
-.menu__link:hover .sidebar-icon svg rect {
-}
-
-/* Style for icons in active menu items */
-.menu__link--active .sidebar-icon svg path,
-.menu__link--active .sidebar-icon svg line,
-.menu__link--active .sidebar-icon svg circle,
-.menu__link--active .sidebar-icon svg rect {
-}
-
-/* For GraphQL logo which uses fill instead of stroke */
-/* .menu__link:hover .sidebar-icon .graphql-icon path, */
-/* .menu__link--active .sidebar-icon .graphql-icon path { */
-/*   fill: var(--ifm-color-primary) !important; */
-/* } */
-
-/* Make sure text color changes on hover and active states */
-.menu__link:hover .menu-label,
-.menu__link--active .menu-label {
-}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -757,6 +757,11 @@ div:has(> .DocSearch.DocSearch-Button) {
   font-size: 0.7rem;
 }
 
+.menu-label {
+  font-size: 0.875rem;
+}
+
+
 .menu__caret:before,
 .menu__link--sublist-caret:after {
   background: var(--ifm-menu-link-sublist-icon) 50% / 1.2rem 1.2rem;
@@ -1756,11 +1761,4 @@ pre[class*='language-'] code span.token {
 /* Make sure text color changes on hover and active states */
 .menu__link:hover .menu-label,
 .menu__link--active .menu-label {
-}
-
-/* Restore correct text weight */
-.menu-label {
-  font-weight: 500;
-  font-size: 14px;
-  color: var(--sidebar-title-color);
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1381,6 +1381,11 @@ table td {
   padding: 1rem;
   padding-bottom: 1rem;
   border-radius: 0.5rem;
+  background-color: var(--dropdown-background-color);
+}
+
+[data-theme='dark'] .tabs-container {
+  background-color: #131d2c;
 }
 
 .tabs-container code {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -27,6 +27,7 @@
   --sidebar-bg-color-hover: #f1f5f9;
   --heading-color: #1f2937;
   --heading-color-hover: #0f172a;
+  --sidebar-title-color: #374151;
   --body-text-color: #374151;
   --dropdown-background-color: #f3f4f6;
   --button-text: #4b5563;
@@ -123,6 +124,7 @@ html[data-theme='dark'] {
   --sidebar-bg-color-hover: #1f2937;
   --heading-color: #e5e7eb;
   --heading-color-hover: #e5e7eb;
+  --sidebar-title-color: #d1d5db;
   --body-text-color: #d1d5db;
   --dropdown-background-color: #1e293b;
   --button-text: #f3f4f6;
@@ -369,6 +371,10 @@ p code {
 
 #hasura-promptql-docs-main-button {
   color: var(--heading-color);
+}
+
+html[data-theme='dark'] #hasura-promptql-docs-main-button {
+  color: var(--primary-neutral-900);
 }
 
 /* -------------- LAYOUT & CONTAINERS -------------- */
@@ -667,21 +673,28 @@ div:has(> .DocSearch.DocSearch-Button) {
   background-color: transparent !important;
 }
 
-/* Breadcrumbs */
+/* -------------- Breadcrumbs -------------- */
 .breadcrumbs {
+  font-family: 'Archivo', sans-serif;
+  font-size: 0.875rem;
   display: flex;
   align-items: center;
   margin-bottom: 2rem;
+  color: var(--primary-neutral-400);
 }
 
 .breadcrumbs__item {
   display: flex;
   align-items: center;
+  color: var(--primary-neutral-400);
 }
 
 .breadcrumbs__item--active .breadcrumbs__link {
   background: none;
-  color: var(--primary-neutral-400);
+}
+
+.breadcrumbs__link {
+  color: var(--primary-neutral-400) !important;
   font-size: 0.875rem;
 }
 
@@ -717,6 +730,7 @@ div:has(> .DocSearch.DocSearch-Button) {
   background: none;
 }
 
+/* Hides version badge under breadcrumbs */
 .theme-doc-version-badge.badge.badge--secondary {
   margin-bottom: 2rem;
   margin-bottom: 2rem; /* sm */
@@ -1293,10 +1307,6 @@ table td {
 }
 
 /* Misc Components */
-.badge--secondary {
-  margin-top: 0.25rem;
-  margin-bottom: 0.25rem;
-}
 
 .anchor {
   margin-bottom: 0.5rem;
@@ -1750,5 +1760,7 @@ pre[class*='language-'] code span.token {
 
 /* Restore correct text weight */
 .menu-label {
-  font-weight: inherit;
+  font-weight: 500;
+  font-size: 14px;
+  color: var(--sidebar-title-color);
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -759,6 +759,7 @@ div:has(> .DocSearch.DocSearch-Button) {
 
 .menu-label {
   font-size: 0.875rem;
+  color: var(--sidebar-title-color);
 }
 
 
@@ -1378,14 +1379,8 @@ table td {
 
 /* Tabs Container */
 .tabs-container {
-  padding: 1rem;
-  padding-bottom: 1rem;
+  padding: 1rem 0;
   border-radius: 0.5rem;
-  background-color: var(--dropdown-background-color);
-}
-
-[data-theme='dark'] .tabs-container {
-  background-color: #131d2c;
 }
 
 .tabs-container code {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -37,7 +37,7 @@
   --inline-code-bg: #f3f4f6;
   --inline-code-border: #e5e7eb;
   --blockquote-margin: #aceb94;
-  --body-list-item-color: #6b7280;
+  --body-list-item-color: var(--heading-color);
   --sidebar-divider: var(--button-drop-shadow);
 
   /* Admonition Colors */
@@ -136,7 +136,7 @@ html[data-theme='dark'] {
   --blockquote-margin: #4ade80;
   --admonition-text-color: #d1d5db;
   --admonition-inline-text-color: #374151;
-  --body-list-item-color: #6b7280;
+  --body-list-item-color: var(--heading-color);
   --sidebar-divider: #1f2937;
 
   --note-bg: #1f2937;


### PR DESCRIPTION
# Description 📝

## Fonts. 
- The fonts weren't actually loading. It was because the `stylesheets` prop was in the wrong place in docusaurus config.
- Fonts in the design are enormous when used at that size on the real site. Have downscaled a bit. CC: @surendran82 

## Sidebar style. 
- Left sidebar titles were quite different to the design. 
- Corrected font, size (a bit), and color
**Before:**
<img width="1689" alt="Screenshot 2025-05-29 at 09 57 02" src="https://github.com/user-attachments/assets/2cf48e54-7d8e-48a3-b118-115a3b8bbca3" />
**After:**
<img width="1683" alt="Screenshot 2025-05-29 at 10 28 10" src="https://github.com/user-attachments/assets/73b9fc3b-faf3-4bc1-883b-064fae072fc7" />

## Dark mode big button
- Fix font color
**Before:**
<img width="643" alt="Screenshot 2025-05-29 at 09 56 47" src="https://github.com/user-attachments/assets/8dd36224-1d72-4b9f-8852-b8f702c0c35f" />
**After:**
<img width="669" alt="Screenshot 2025-05-29 at 09 56 54" src="https://github.com/user-attachments/assets/aa4e26fa-79bf-405a-a963-2c55df36bfeb" />

## Breadcrumbs 
- Size and color to be consistent with design. (Size taken down a bit because design is huge on site)
**Before:**
<img width="601" alt="Screenshot 2025-05-29 at 10 42 35" src="https://github.com/user-attachments/assets/42bd29a1-e4af-462d-9f5c-3895bf8ea217" />
**After:**
<img width="578" alt="Screenshot 2025-05-29 at 10 42 05" src="https://github.com/user-attachments/assets/66abc079-0e2b-4c6a-aed8-9d05b0e9d0ee" />

## Heading sizes
- Bump heading sizes to be more like designs
**Before:**
<img width="937" alt="Screenshot 2025-05-29 at 11 50 20" src="https://github.com/user-attachments/assets/e784d0e6-e4a2-4c95-a7e6-e425a74bee1d" />
**After:**
<img width="906" alt="Screenshot 2025-05-29 at 11 50 29" src="https://github.com/user-attachments/assets/6fcf02e0-8c56-4cf3-aae3-b88b1964760f" />

## Tabs
- Remove tabs left right padding as per design
**After:**
<img width="911" alt="Screenshot 2025-05-29 at 12 33 20" src="https://github.com/user-attachments/assets/8491f270-2599-46f9-9845-df2b6292cbb7" />

## Lists TEMP
- Knocked back color looked very strange changed to text color for now
- The primary neutral colors in the CSS are still from Tailwind defaults. Would be good if these were on-theme so we could use them for things like this. CC: @surendran82 
**Before:**
<img width="899" alt="Screenshot 2025-05-29 at 11 18 49" src="https://github.com/user-attachments/assets/e5ccedc4-554b-46a4-b796-52af4d5b4b4e" />
<img width="888" alt="Screenshot 2025-05-29 at 11 18 22" src="https://github.com/user-attachments/assets/084b3f3f-6807-441e-a1e0-78d7e94f6c80" />

**After:**
<img width="938" alt="Screenshot 2025-05-29 at 11 19 00" src="https://github.com/user-attachments/assets/dc554d39-cb2a-46bb-911a-c2b2074a44f4" />
<img width="925" alt="Screenshot 2025-05-29 at 11 18 33" src="https://github.com/user-attachments/assets/05b47be7-b42c-4dde-aeb6-059e56bfe123" />

# Quick Links 🚀

[Root](https://sean-robdominguez-doc-2822-i.promptql-docs.pages.dev/)

