### PR TITLE
Docs: align documentation messaging with updated terminology from

### DIFF
--- a/docs/auth/faq.mdx
+++ b/docs/auth/faq.mdx
@@ -23,7 +23,7 @@ slower than JWT mode due to the additional network request.
 You can test permissions directly in the Playground's interface:
 
 1. Define the desired permissions for a particular Type, Model, or Command in your metadata.
-2. Create a new build of your supergraph.
+2. Create a new build.
 3. Make a request through the PromptQL Playground with an auth token that includes the required session variables; you
    can do this by clicking the `Auth` button in the prompt input.
 4. Check the returned data to ensure it adheres to your permission configurations.

--- a/docs/auth/jwt/index.mdx
+++ b/docs/auth/jwt/index.mdx
@@ -19,7 +19,7 @@ keywords:
 
 # JWT Mode
 
-In JWT mode, session variables are passed to the Hasura Engine on each request in JSON Web Tokens (JWTs).
+In JWT mode, session variables are passed to the distributed query engine on each request in JSON Web Tokens (JWTs).
 
 ## JWT mode setup
 

--- a/docs/auth/jwt/jwt-configuration.mdx
+++ b/docs/auth/jwt/jwt-configuration.mdx
@@ -88,7 +88,7 @@ AuthConfig. Using `claims.jwt.hasura.io` will match our examples.
 3.  Add any other optional `x-hasura-*` claim fields (required as per your defined permissions) to the custom namespace.
 
 To summarize, `x-hasura-allowed-roles` session variable contains a list of all the roles that the user can assume and
-the `x-hasura-role` header tells the Hasura Engine which role to use for the request, and if that is missing then the
+the `x-hasura-role` header tells the query engine which role to use for the request, and if that is missing then the
 `x-hasura-default-role` session variable will be used.
 
 This setup makes it more convenient for a JWT to only need to be issued once with a list of allowed roles for the user,
@@ -99,8 +99,8 @@ If, for example, your app will not need to switch user roles and the user only n
 can just issue a JWT with `x-hasura-default-role` set to `user` and `x-hasura-allowed-roles` set to `["user"]` and not
 send the `x-hasura-role` header in the request.
 
-This setup is designed so that there is one authoritative way to construct your JWT token for the Hasura Engine which
-can cover a wide range of use cases.
+This setup is designed so that there is one authoritative way to construct your JWT token for the query engine which can
+cover a wide range of use cases.
 
 ## Hasura JWT Claim Description
 
@@ -114,7 +114,7 @@ the header of the request. Usually, this will be the role with the least privile
 
 The `x-hasura-allowed-roles` list can contain all the roles which a particular user can assume, eg:
 `[ "user", "manager", "owner" ]`. Usually, these will have varying degrees of access to your data as specified in
-Permissions and by specifying this list it lets the Hasura Engine know that this user can assume any of them.
+Permissions and by specifying this list it lets the query engine know that this user can assume any of them.
 
 ### x-hasura-\*
 
@@ -127,8 +127,8 @@ your auth provider.
 ## JWT Notes
 
 - JWT claim fields eg: `x-hasura-default-role` are case-insensitive.
-- Hasura Engine only has access to headers and JWT claims which are prefixed with `x-hasura-`.
-- Hasura Engine only has access to JWT claims in namespace defined in the `AuthConfig` object in metadata.
+- The query engine only has access to headers and JWT claims which are prefixed with `x-hasura-`.
+- The query engine only has access to JWT claims in namespace defined in the `AuthConfig` object in metadata.
 - All `x-hasura-*` values should be of type `String`, they will be converted to the right type automatically.
 
 ## Hasura JWT configuration options
@@ -140,7 +140,7 @@ You can specify where the engine should look for the claims within the decoded t
 
 #### namespace {#jwt-claims-config-namespace}
 
-The `namespace` option is used when all of the Hasura claims are present in a single object within the decoded JWT. Our
+The `namespace` option is used when all of your claims are present in a single object within the decoded JWT. Our
 example uses `claims.jwt.hasura.io` in the [Example Decoded Payload](#example-decoded-payload).
 
 ```yaml
@@ -193,8 +193,8 @@ If `claimsFormat` is `StringifiedJson` then the JWT claims should look like:
 
 #### locations {#jwt-claims-config-locations}
 
-This `locations` option can be used when Hasura claims are not all present in the single object, but individual claims
-are provided a JSON pointer within the decoded JWT. In this option, you can indicate:
+This `locations` option can be used when your claims are not all present in the single object, but individual claims are
+provided a JSON pointer within the decoded JWT. In this option, you can indicate:
 
 - a literal value.
 - or a JSON pointer path for individual claims and an optional default value if the claim doesn't exist.
@@ -309,7 +309,7 @@ The following are the possible values:
 
 #### BearerAuthorization
 
-In this mode, Hasura expects an `Authorization` header with a `Bearer` token.
+In this mode, the query engine expects an `Authorization` header with a `Bearer` token.
 
 ```yaml
 tokenLocation:
@@ -324,8 +324,8 @@ Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWI...
 
 #### Cookie
 
-In the cookie mode, Hasura will try to parse the cookie header with the given cookie name. The value of the cookie
-should be the exact JWT.
+In the cookie mode, the query engine will try to parse the cookie header with the given cookie name. The value of the
+cookie should be the exact JWT.
 
 ```yaml
 tokenLocation:
@@ -341,7 +341,7 @@ Cookie: cookie_name=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWI...
 
 #### Header
 
-In the custom header mode, Hasura expects a `header_name` header with the exact JWT token value.
+In the custom header mode, the query engine expects a `header_name` header with the exact JWT token value.
 
 ```yaml
 tokenLocation:
@@ -402,7 +402,7 @@ key:
 The JWTs must be signed by the JWK published at the given URL. They can be signed by any algorithm that is compatible
 with the key (eg. `RS256`, `RS384`, `RS512` algorithms require a JWK with an RSA key).
 
-Hasura DDN does not currently support rotating JWKs.
+The query engine does not currently support rotating JWKs.
 
 ### audience
 
@@ -440,8 +440,8 @@ definition:
 :::danger Audience Security Vulnerability
 
 Certain JWT providers share JWKs between multiple tenants. They use the `aud` claim of the JWT to specify the intended
-audience. Setting the `audience` field in the Hasura JWT configuration will make sure that the `aud` claim from the JWT
-is also checked during verification. Not doing this check will allow JWTs issued for other tenants to be valid as well.
+audience. Setting the `audience` field in the WT configuration will make sure that the `aud` claim from the JWT is also
+checked during verification. Not doing this check will allow JWTs issued for other tenants to be valid as well.
 
 In these cases, you **MUST** set the `audience` field to the appropriate value. Failing to do so is a **major security
 vulnerability**.
@@ -508,7 +508,7 @@ definition:
             value: 3EK6FD+o0+c7tzBNVfjpMkNDi2yARAAKzQlk8O2IKoxQu4nF7EdAh8s3TwpHwrdWT6R
 ```
 
-The `key` is the actual shared secret, which is used by Hasura and the external auth server.
+The `key` is the actual shared secret, which is used by the query engine and the external auth server.
 
 #### RSA based
 
@@ -709,9 +709,9 @@ definition:
 ### Setting audience check
 
 Certain JWT providers share JWKs between multiple tenants (like Firebase). They use the `aud` claim of JWT to specify
-the intended tenant for the JWT. Setting the `audience` field in the Hasura JWT configuration will make sure that the
-`aud` claim from the JWT is also checked during verification. Not doing this check will allow JWTs issued for other
-tenants to be valid as well.
+the intended tenant for the JWT. Setting the `audience` field in the JWT configuration will make sure that the `aud`
+claim from the JWT is also checked during verification. Not doing this check will allow JWTs issued for other tenants to
+be valid as well.
 
 In these cases, you **MUST** set the `audience` field to appropriate value. **Failing to do so is a major security
 vulnerability**.
@@ -719,8 +719,8 @@ vulnerability**.
 ## JWT with the WebSocket protocol
 
 When executing a subscription (or query or mutation) over the WebSocket protocol, the authentication step is executed on
-`connection_init` when the websocket is connected to Hasura Engine and is valid until the expiry of the JWT when in JWT
-mode.
+`connection_init` when the websocket is connected to the query engine and is valid until the expiry of the JWT when in
+JWT mode.
 
 Once authenticated, all operations are allowed without further check, until the authentication expires.
 
@@ -737,8 +737,8 @@ This is a known issue and is documented by AWS in
 > Standard libraries are not compatible with the padding that is included in the Application Load Balancer
 > authentication token in JWT format.
 
-Currently, there is no workaround possible in Hasura. Even if Hasura strips the additional padding the signature
-verification of the token would fail (as Hasura had to tamper the token).
+Currently, there is no workaround possible in the query engine; even if we strip the additional padding, the signature
+verification of the token would fail (as we've tampered with the token).
 
 ### Firebase
 
@@ -746,7 +746,7 @@ Firebase publishes the JWKs at:
 
 [https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com](https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com)
 
-If you are using Firebase and Hasura, use this config:
+If you are using Firebase, use this config:
 
 ```yaml
 kind: AuthConfig
@@ -770,18 +770,18 @@ definition:
 ### Auth0 {#auth0-issues}
 
 Refer to the [Auth0 JWT tutorial](/auth/jwt/tutorials/integrations/1-auth0.mdx) for a detailed guide on integrating
-Auth0 with Hasura.
+Auth0.
 
 ### Clerk
 
-Clerk integrates with Hasura DDN using JWTs.
+Clerk integrates with the query engine using JWTs.
 
 Clerk publishes their JWK under: `https://<YOUR_CLERK_FRONTEND_API>/.well-known/jwks.json`
 
-Refer to the [Clerk JWT tutorial](/auth/jwt/tutorials/integrations/4-clerk.mdx) to set up authenticated requests to
-Hasura with Clerk.
+Refer to the [Clerk JWT tutorial](/auth/jwt/tutorials/integrations/4-clerk.mdx) to set up authenticated requests with
+Clerk.
 
 ### Keycloak
 
-By default, Keycloak uses the `RSA-OAEP` algorithm, which Hasura doesn't support. Remove the algorithm in the
-`Realm Settings -> Keys -> Add Providers` tab.
+By default, Keycloak uses the `RSA-OAEP` algorithm, which the distributed query engine doesn't support. Remove the
+algorithm in the `Realm Settings -> Keys -> Add Providers` tab.

--- a/docs/auth/jwt/jwt-mode.mdx
+++ b/docs/auth/jwt/jwt-mode.mdx
@@ -21,8 +21,8 @@ import Thumbnail from "@site/src/components/Thumbnail";
 JWT mode requires that the client making the request sends a valid JSON Web Token to application. This JWT is provided
 by an auth service such as Auth0, AWS Cognito, Firebase, Clerk, or your own custom solution.
 
-Hasura then verifies and decodes the JWT to extract `x-hasura-*` session variable claim values from a defined namespace
-in the token.
+The query engine then verifies and decodes the JWT to extract `x-hasura-*` session variable claim values from a defined
+namespace in the token.
 
 The `x-hasura-default-role` and `x-hasura-allowed-roles` session variables are required, and you will also most likely
 utilize the user id and any other information which you need to determine access to your data.
@@ -53,9 +53,9 @@ You can enable your application to use JWTs in just a few steps.
 
 ### Step 1. Update your AuthConfig
 
-Hasura utilizes an [AuthConfig](/reference/metadata-reference/auth-config.mdx) object that allows you to define the
-configuration for your authentication service. In a standard setup the `auth-config.hml` file can be found in your
-`globals` directory.
+Your application utilizes an [AuthConfig](/reference/metadata-reference/auth-config.mdx) metadata object that allows you
+to define the configuration for your authentication service. In a standard setup the `auth-config.hml` file can be found
+in your `globals` directory.
 
 :::tip Hasura VS Code extension
 
@@ -129,9 +129,9 @@ The signature secret to verify this token with the HS256 algorithm is `ultra-sec
 :::warning Setting audience check
 
 Certain JWT providers (like Firebase) share JWKs between multiple tenants. They use the `aud` claim of JWT to specify
-the intended tenant for the JWT. Setting the `audience` field in the Hasura JWT configuration will make sure that the
-`aud` claim from the JWT is also checked during verification. Not doing this check will allow JWTs issued for other
-tenants to be valid as well.
+the intended tenant for the JWT. Setting the `audience` field in the `auth-config.yaml` will make sure that the `aud`
+claim from the JWT is also checked during verification. Not doing this check will allow JWTs issued for other tenants to
+be valid as well.
 
 In these cases, you **MUST** set the `audience` field to appropriate value. **Failing to do so is a major security
 vulnerability**. Learn how to set this [here](reference/metadata-reference/auth-config.mdx#authconfig-jwtconfig).
@@ -234,9 +234,9 @@ ddn supergraph build local
 
 ### Step 5. Make an authenticated request
 
-In the example above, we're using the `BearerAuthorization` method. As such, as we can make a request to our Hasura DDN
-instance by including a header with the key-value of `Authorization: Bearer <our-encoded-token>`. For testing, you can
-pass this value in via the [PromptQL Playground client](/auth/playground-auth.mdx).
+In the example above, we're using the `BearerAuthorization` method. As such, as we can make a request to our application
+by including a header with the key-value of `Authorization: Bearer <our-encoded-token>`. For testing, you can pass this
+value in via the [PromptQL Playground](/auth/playground-auth.mdx).
 
 ## Next steps
 

--- a/docs/auth/jwt/tutorials/index.mdx
+++ b/docs/auth/jwt/tutorials/index.mdx
@@ -14,7 +14,7 @@ seoFrontMatterUpdated: false
 ## Introduction
 
 In this section of tutorials, we'll provide you with concise up-to-date descriptions of how to connect your preferred
-authentication provider to Hasura DDN.
+authentication provider.
 
 ## Tutorials
 

--- a/docs/auth/jwt/tutorials/integrations/1-auth0.mdx
+++ b/docs/auth/jwt/tutorials/integrations/1-auth0.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 2
 sidebar_label: Auth0
-description: "Learn how to connect Auth0 to your Hasura DDN supergraph."
+description: "Learn how to connect Auth0 to your PromptQL application."
 keywords:
   - hasura
   - hasura ddn
@@ -22,7 +22,7 @@ In this tutorial, you'll learn how to configure an existing [Auth0 application](
 which you can pass in the header of your requests. After setting up your
 [AuthConfig](/reference/metadata-reference/auth-config.mdx) object to use JWT mode, this will allow you to validate
 users' identities and create [permission rules](/reference/metadata-reference/permissions.mdx) which can limit access to
-underlying data served by Hasura DDN to PromptQL.
+underlying data served by the query engine to PromptQL.
 
 :::info Prerequisites
 
@@ -57,8 +57,7 @@ Enter a name for your Action such as `Hasura JWT Claims` and paste the following
 ```javascript
 exports.onExecutePostLogin = async (event, api) => {
   const namespace = "claims.jwt.hasura.io";
-  // Here, you'll need to fetch the user's role from Hasura DDN using an admin-level authenticated request
-  // Learn more here: https://hasura.io/docs/3.0/auth/authentication/jwt/special-roles
+  // Here, you'll need to fetch the user's role from the underlying data source using an admin-level authenticated request
   // Below, we're hard-coding the value for now
   const user_role = "user"; // the role returned from your request ☝️
   api.idToken.setCustomClaim(namespace, {
@@ -68,7 +67,7 @@ exports.onExecutePostLogin = async (event, api) => {
     // Add any other custom claims you wish to include
   });
 
-  // Set the necessary access token claims for Hasura to authenticate the user
+  // Set the necessary access token claims for the query engine to authenticate the user
   api.accessToken.setCustomClaim(namespace, {
     "x-hasura-default-role": user_role,
     "x-hasura-allowed-roles": [user_role],
@@ -77,15 +76,15 @@ exports.onExecutePostLogin = async (event, api) => {
 };
 ```
 
-This will add the required Hasura namespace with the keys that Hasura DDN expects when decoding a JWT. You can modify
-the keys to suit your application's [roles](/reference/metadata-reference/permissions.mdx#typepermissions).
+This will add the required `Hasura` namespace with the keys that the query engine expects when decoding a JWT. You can
+modify the keys to suit your application's [roles](/reference/metadata-reference/permissions.mdx#typepermissions).
 
 Click `Deploy`.
 
 :::tip Custom claims
 
 You can create any custom keys you wish and reference them in your permissions using session variables. Above,
-`x-hasura-user-id` is simply an example. Any claim prefixed with `x-hasura-` is accessible to the Hasura DDN Engine.
+`x-hasura-user-id` is simply an example. Any claim prefixed with `x-hasura-` is accessible to the query engine.
 
 :::
 
@@ -199,10 +198,9 @@ oversights.
 
 ## Wrapping up
 
-In this guide, you learned how to integrate Auth0 with Hasura DDN and PromptQL to create a secure and scalable identity
-management solution using JWTs. By leveraging custom claims in conjunction with
-[permissions](/reference/metadata-reference/permissions.mdx), you can define precise access-control rules, ensuring that
-your application remains secure and meets your users' needs.
+In this guide, you learned how to integrate Auth0 to create a secure and scalable identity management solution using
+JWTs. By leveraging custom claims in conjunction with [permissions](/reference/metadata-reference/permissions.mdx), you
+can define precise access-control rules, ensuring that your application remains secure and meets your users' needs.
 
 As you continue building out your application, keep in mind that authentication and authorization are crucial
 components. Always validate your configuration and regularly test your setup to ensure it functions as expected across

--- a/docs/auth/jwt/tutorials/integrations/2-aws-cognito.mdx
+++ b/docs/auth/jwt/tutorials/integrations/2-aws-cognito.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 3
 sidebar_label: AWS Cognito
-description: "Learn how to connect AWS Cognito to your Hasura DDN supergraph."
+description: "Learn how to connect AWS Cognito to your PromptQL application."
 keywords:
   - hasura
   - hasura ddn
@@ -21,10 +21,10 @@ seoFrontMatterUpdated: false
 
 In this tutorial, you'll learn how to configure an existing
 [AWS Cognito user pool](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools.html) and generate
-a JWT which you can pass in the header of your requests to Hasura. After setting up your
+a JWT which you can pass in the header of your requests. After setting up your
 [AuthConfig](/reference/metadata-reference/auth-config.mdx) object to use JWT mode, this will allow you to validate
 users' identities and create [permission rules](/reference/metadata-reference/permissions.mdx) which can limit access to
-underlying data served by Hasura DDN.
+underlying data served by the query engine to PromptQL.
 
 :::info Prerequisites
 
@@ -32,7 +32,7 @@ Before continuing, ensure you have:
 
 - An AWS Cognito [user pool](https://manage.auth0.com/dashboard) with a domain configured.
 - A local application that can integrate with Cognito for authentication.
-- A local Hasura project.
+- A local PromptQL project.
 
 :::
 
@@ -40,19 +40,18 @@ Before continuing, ensure you have:
 
 ### Step 1. Create a Lambda trigger for modifying JWT claims
 
-To add the custom claims that Hasura requires, you will need to create an AWS Lambda function and set it as a trigger
-for your Cognito user pool.
+To add the custom claims that the query engine requires, you will need to create an AWS Lambda function and set it as a
+trigger for your Cognito user pool.
 
 In the [AWS Lambda console](https://console.aws.amazon.com/lambda/home), create a new Lambda function. Select the
 `Author from scratch` option and provide a name, runtime, architecture, and any advanced settings you wish to configure.
 
 After your Lambda is created, you'll be redirected to an editor where you can modify the Lambda's handler. Add the
-following code to modify the Cognito JWT and inject the custom Hasura namespace claims:
+following code to modify the Cognito JWT and inject the custom `Hasura` namespace claims:
 
 ```javascript
 export const handler = async (event) => {
-  // Here, you'll need to fetch the user's role from Hasura DDN using an admin-level authenticated request
-  // Learn more here: https://hasura.io/docs/3.0/auth/authentication/jwt/special-roles
+  // Here, you'll need to fetch the user's role from the underlying data source using an admin-level authenticated request
   // Below, we're hard-coding the value for now
   const user_role = "user"; // the role returned from your request ☝️
   event.response = {
@@ -71,15 +70,15 @@ export const handler = async (event) => {
 };
 ```
 
-This will add the required Hasura namespace with the keys that Hasura expects when decoding a JWT. You can modify the
-keys to suit your application's [roles](/reference/metadata-reference/permissions.mdx#typepermissions).
+This will add the required `Hasura` namespace with the keys that the query engine expects when decoding a JWT. You can
+modify the keys to suit your application's [roles](/reference/metadata-reference/permissions.mdx#typepermissions).
 
 Click `Deploy`.
 
 :::tip Custom claims
 
 You can create any custom keys you wish and reference them in your permissions using session variables. Above,
-`x-hasura-user-id` is simply an example. Any claim prefixed with `x-hasura-` is accessible to Hasura.
+`x-hasura-user-id` is simply an example. Any claim prefixed with `x-hasura-` is accessible to the query engine.
 
 :::
 
@@ -127,14 +126,14 @@ have in your metadata.
 
 ## Wrapping up
 
-In this guide, you learned how to integrate AWS Cognito with PromptQL to create a secure and scalable identity
-management solution using JWTs. By leveraging custom claims in conjunction with
+In this guide, you learned how to integrate AWS Cognito to create a secure and scalable identity management solution
+using JWTs. By leveraging custom claims in conjunction with
 [permissions](/reference/metadata-reference/permissions.mdx), you can define precise access-control rules, ensuring that
 your application remains secure and meets your users' needs.
 
-As you continue building out your supergraph, keep in mind that authentication and authorization are crucial components.
-Always validate your configuration and regularly test your setup to ensure it functions as expected across different
-roles and environments.
+As you continue building out your application, keep in mind that authentication and authorization are crucial
+components. Always validate your configuration and regularly test your setup to ensure it functions as expected across
+different roles and environments.
 
 If you encounter issues or need further customization, consider reviewing our related documentation or exploring
 additional AWS Cognito features that can enhance your authentication flows.

--- a/docs/auth/jwt/tutorials/integrations/3-firebase.mdx
+++ b/docs/auth/jwt/tutorials/integrations/3-firebase.mdx
@@ -19,10 +19,10 @@ seoFrontMatterUpdated: false
 ## Introduction
 
 In this tutorial, you'll learn how to configure an existing [Firebase project](https://console.firebase.google.com/) and
-generate a JWT which you can pass in the header of your requests to Hasura. After setting up your
+generate a JWT which you can pass in the header of your requests. After setting up your
 [AuthConfig](/reference/metadata-reference/auth-config.mdx) object to use JWT mode, this will allow you to validate
 users' identities and create [permission rules](/reference/metadata-reference/permissions.mdx) which can limit access to
-underlying data served by Hasura DDN.
+underlying data served by the query engine to PromptQL.
 
 :::info Prerequisites
 
@@ -33,7 +33,7 @@ Before continuing, ensure you have:
   below.
 - A private key from the project's `Service Accounts` section via the
   [Firebase console](https://console.firebase.google.com/project/_/settings/serviceaccounts/adminsdk).
-- A local Hasura project.
+- A local PromptQL project.
 
 :::
 
@@ -64,8 +64,7 @@ admin.initializeApp({ credential: admin.credential.cert(require("./service_accou
 #### Step 1.3 Add the custom claims
 
 ```javascript
-// Here, you'll need to fetch the user's role from Hasura using an admin-level authenticated request
-// Learn more here: https://hasura.io/docs/3.0/auth/authentication/jwt/special-roles
+// Here, you'll need to fetch the user's role from the underlying data source using an admin-level authenticated request
 // Below, we're hard-coding the value for now
 const user_role = "user"; // the role returned from your request ☝️
 const customClaims = {
@@ -80,13 +79,13 @@ const customClaims = {
 await admin.auth().setCustomUserClaims(decodedToken.uid, customClaims);
 ```
 
-This will add the required Hasura namespace with the keys that Hasura expects when decoding a JWT. You can modify the
-keys to suit your application's [roles](/reference/metadata-reference/permissions.mdx#typepermissions).
+This will add the required `Hasura` namespace with the keys the query engine expects when decoding a JWT. You can modify
+the keys to suit your application's [roles](/reference/metadata-reference/permissions.mdx#typepermissions).
 
 :::tip Custom claims
 
 You can create any custom keys you wish and reference them in your permissions using session variables. Above,
-`x-hasura-user-id` is simply an example. Any claim prefixed with `x-hasura-` is accessible to the Hasura DDN Engine.
+`x-hasura-user-id` is simply an example. Any claim prefixed with `x-hasura-` is accessible to the query engine.
 
 :::
 
@@ -177,8 +176,7 @@ app.post("/login", async (req, res) => {
     // Verify the token using Firebase Admin SDK
     const decodedToken = await admin.auth().verifyIdToken(idToken);
 
-    // Here, you'll need to fetch the user's role from Hasura DDN using an admin-level authenticated request
-    // Learn more here: https://hasura.io/docs/3.0/auth/authentication/jwt/special-roles
+    // Here, you'll need to fetch the user's role from the underlying data source using an admin-level authenticated request
     // Below, we're hard-coding the value for now
     const user_role = "user"; // the role returned from your request ☝️
     const customClaims = {
@@ -211,14 +209,13 @@ app.listen(4000, () => {
 
 ## Wrapping up
 
-In this guide, you learned how to integrate Firebase with Hasura DDN and PromptQL to create a secure and scalable
-identity management solution using JWTs. By leveraging custom claims in conjunction with
-[permissions](/reference/metadata-reference/permissions.mdx), you can define precise access-control rules, ensuring that
-your application remains secure and meets your users' needs.
+In this guide, you learned how to integrate Firebase to create a secure and scalable identity management solution using
+JWTs. By leveraging custom claims in conjunction with [permissions](/reference/metadata-reference/permissions.mdx), you
+can define precise access-control rules, ensuring that your application remains secure and meets your users' needs.
 
-As you continue building out your supergraph, keep in mind that authentication and authorization are crucial components.
-Always validate your configuration and regularly test your setup to ensure it functions as expected across different
-roles and environments.
+As you continue building out your application, keep in mind that authentication and authorization are crucial
+components. Always validate your configuration and regularly test your setup to ensure it functions as expected across
+different roles and environments.
 
 If you encounter issues or need further customization, consider reviewing our related documentation or exploring
 additional Firebase features that can enhance your authentication flows.

--- a/docs/auth/jwt/tutorials/integrations/4-clerk.mdx
+++ b/docs/auth/jwt/tutorials/integrations/4-clerk.mdx
@@ -18,10 +18,10 @@ seoFrontMatterUpdated: false
 ## Introduction
 
 In this tutorial, you'll learn how to configure an existing [Clerk application](https://clerk.com/) and generate a JWT
-which you can pass in the header of your requests to Hasura. After setting up your
+which you can pass in the header of your requests. After setting up your
 [AuthConfig](/reference/metadata-reference/auth-config.mdx) object to use JWT mode, this will allow you to validate
 users' identities and create [permission rules](/reference/metadata-reference/permissions.mdx) which can limit access to
-underlying data served by Hasura DDN.
+underlying data served by the query engine to PromptQL.
 
 :::info Prerequisites
 
@@ -29,7 +29,7 @@ Before continuing, ensure you have:
 
 - A [Clerk application](https://clerk.com/docs/quickstarts/setup-clerk).
 - A local application that can integrate with Clerk for authentication.
-- A local Hasura project.
+- A local PromptQL project.
 
 ### Step 1. Create a JWT template
 
@@ -51,8 +51,8 @@ In the claims editor, add the following:
 }
 ```
 
-This will add the required Hasura namespace with the keys that Hasura expects when decoding a JWT. You can modify the
-keys to suit your application's [roles](/reference/metadata-reference/permissions.mdx#typepermissions).
+This will add the required `Hasura` namespace with the keys the query engine expects when decoding a JWT. You can modify
+the keys to suit your application's [roles](/reference/metadata-reference/permissions.mdx#typepermissions).
 
 You can also see that we're hard-coding the user's role. You can dynamically set a user's role using Clerk's metadata to
 set a `role` field on the `User` object whenever a user registers. You can learn more
@@ -63,7 +63,7 @@ This enables you to then pass the value of `{{user.publicMetadata.role}}` in the
 :::tip Custom claims
 
 You can create any custom keys you wish and reference them in your permissions using session variables. Above,
-`x-hasura-user-id` is simply an example. Any claim prefixed with `x-hasura-` is accessible to the Hasura.
+`x-hasura-user-id` is simply an example. Any claim prefixed with `x-hasura-` is accessible to the query engine.
 
 :::
 
@@ -110,14 +110,13 @@ const jwt = await session.getToken({ template: "hasura" });
 
 ## Wrapping up
 
-In this guide, you learned how to integrate Clerk with Hasura DDN and PromptQL to create a secure and scalable identity
-management solution using JWTs. By leveraging custom claims in conjunction with
-[permissions](/reference/metadata-reference/permissions.mdx), you can define precise access-control rules, ensuring that
-your application remains secure and meets your users' needs.
+In this guide, you learned how to integrate Clerk to create a secure and scalable identity management solution using
+JWTs. By leveraging custom claims in conjunction with [permissions](/reference/metadata-reference/permissions.mdx), you
+can define precise access-control rules, ensuring that your application remains secure and meets your users' needs.
 
-As you continue building out your supergraph, keep in mind that authentication and authorization are crucial components.
-Always validate your configuration and regularly test your setup to ensure it functions as expected across different
-roles and environments.
+As you continue building out your application, keep in mind that authentication and authorization are crucial
+components. Always validate your configuration and regularly test your setup to ensure it functions as expected across
+different roles and environments.
 
 If you encounter issues or need further customization, consider reviewing our related documentation or exploring
 additional Clerk features that can enhance your authentication flows.

--- a/docs/auth/jwt/tutorials/integrations/index.mdx
+++ b/docs/auth/jwt/tutorials/integrations/index.mdx
@@ -14,7 +14,7 @@ seoFrontMatterUpdated: false
 ## Introduction
 
 In this section of tutorials, we'll provide you with concise up-to-date descriptions of how to connect your preferred
-authentication provider to Hasura DDN.
+authentication provider.
 
 ## Tutorials
 

--- a/docs/auth/jwt/tutorials/setup-test-jwt.mdx
+++ b/docs/auth/jwt/tutorials/setup-test-jwt.mdx
@@ -14,7 +14,7 @@ seoFrontMatterUpdated: true
 
 # Set up a JWT for Testing
 
-By default, your supergraph uses your Hasura Cloud authentication token, also known as a personal access token (PAT),
+By default, your application uses your Hasura Cloud authentication token, also known as a personal access token (PAT),
 for authentication. This is convenient for testing from the Playground, but should not be used in an application or
 shared with others.
 
@@ -70,7 +70,7 @@ definition:
 
 ## Step 4. Create a new build
 
-Create a supergraph build using this `AuthConfig`.
+Create a new build using this `AuthConfig`.
 
 ```ddn title="From the root of your project, run:"
 ddn supergraph build create --description "use jwt-based authconfig"
@@ -92,7 +92,7 @@ In the example above, we're setting the following values:
 - The default role as `admin`.
 - The allowed roles as `admin`.
 
-For more information about the claims Hasura expects, check out [this page](/auth/jwt/jwt-configuration.mdx).
+For more information about the claims the query engine expects, check out [this page](/auth/jwt/jwt-configuration.mdx).
 
 ## Step 6: Test your AuthConfig
 

--- a/docs/auth/noauth-mode.mdx
+++ b/docs/auth/noauth-mode.mdx
@@ -14,9 +14,8 @@ import Thumbnail from "@site/src/components/Thumbnail";
 
 ## Introduction
 
-NoAuth mode is a simple way to run your Hasura DDN and PromptQL instance without authentication and is enabled by
-default. This is useful for testing or development purposes or to run your project as fully public without any
-authentication.
+NoAuth mode is a simple way to run your application without authentication and is enabled by default. This is useful for
+testing or development purposes or to run your project as fully public without any authentication.
 
 :::danger Production Warning
 

--- a/docs/auth/overview.mdx
+++ b/docs/auth/overview.mdx
@@ -22,22 +22,21 @@ keywords:
 
 ## Introduction
 
-By default, PromptQL accesses your data through Hasura DDN in [NoAuth](/auth/noauth-mode.mdx) mode as an `admin` user.
-This means that by default on a new installation, it has full access to your data.
+By default, PromptQL accesses your data through the distributed query engine in [NoAuth](/auth/noauth-mode.mdx) mode as
+an `admin` user. This means that by default on a new installation, it has full access to your data.
 
 However, you can integrate many popular auth services or use your own custom solution to authenticate users.
 
 After the authentication step, session variables, including a user role, are passed via either a valid JWT or webhook
-response, to the Hasura Engine to be checked against the access control rules or "permissions" to determine what data
-the user can access. This ensures any PromptQL conversations are scoped to only return information that a particular
-user is permitted to access.
+response, to the query engine to be checked against the access control rules or "permissions" to determine what data the
+user can access. This ensures any PromptQL conversations are scoped to only return information that a particular user is
+permitted to access.
 
-As you will most often be using PromptQL in the console interface, you can check the auth which the client is using by
-clicing the "Auth" button on the left of the chat textbox.
-
-## PromptQL Playground Auth
+:::info Which auth mode am I using?
 
 Learn how to check the auth which the PromptQL Playground client is using [here](/auth/playground-auth.mdx).
+
+:::
 
 ## AuthConfig options
 
@@ -46,8 +45,8 @@ Authentication can be set up in one of three modes. These modes and their config
 
 ### JWT mode
 
-Your authentication service must issue JWTs which contain session variables that are passed to the Hasura Engine by the
-PromptQL client on each request.
+Your authentication service must issue JWTs which contain session variables that are passed to the distributed query
+engine by PromptQL on each request.
 
 [Read more](/auth/jwt/index.mdx).
 

--- a/docs/auth/permissions/command-permissions.mdx
+++ b/docs/auth/permissions/command-permissions.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 3
 description:
-  "Guide on configuring command permissions in your supergraph, including role-based access and argument presets."
+  "Guide on configuring command permissions in your metadata, including role-based access and argument presets."
 keywords:
   - command permissions
   - role-based access
@@ -14,7 +14,7 @@ sidebar_label: Command Permissions
 
 To limit what **commands** are available to a role, you define a `CommandPermissions` object.
 
-By default, whenever a new command is created in your supergraph, it is only executable by the `admin` role.
+By default, whenever a new command is created in your metadata, it is only executable by the `admin` role.
 
 You can enable or restrict access to commands by adding a new item to the `permissions` array in the
 `CommandPermissions` object. Each item in the array should have a `role` field and an `allowExecution` field. The

--- a/docs/auth/permissions/model-permissions.mdx
+++ b/docs/auth/permissions/model-permissions.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Guide on setting up model permissions in your supergraph"
+description: "Guide on setting up model permissions in your metadata."
 keywords:
   - model permissions
   - supergraph
@@ -13,14 +13,14 @@ sidebar_label: Model Permissions
 To limit what **data** in a model is available to a role, you define a `ModelPermissions` object with a `filter`
 expression.
 
-By default, whenever a new model is created in your supergraph, all records are only accessible to the `admin` role. You
+By default, whenever a new model is created in your metadata, all records are only accessible to the `admin` role. You
 can think of these as permissions on rows in a typical relational database table.
 
 You can restrict access to certain data by adding a new item to the `permissions` array in the `ModelPermissions`
 object. Each item in the array should have a `role` field and a `select` field. The `select` field should contain a
 `filter` expression that determines which rows are accessible to the role when selecting from the model.
 
-Most commonly, you'll use session variables — accessed by Hasura via your configured
+Most commonly, you'll use session variables — accessed by the query engine via your configured
 [authentication mechanism](/auth/overview.mdx) in a JWT or body of a webhook response — to restrict access to rows based
 on the user's role, identity or other criteria.
 
@@ -35,8 +35,8 @@ This filter expression can reference
 
 :::info Remote Relationships in Permissions
 
-Remote relationships (relationships between different data connectors) across subgraphs are not supported in permission
-filters.
+Remote relationships (relationships between different data connectors) across
+[subgraphs](/project-configuration/subgraphs/index.mdx) are not supported in permission filters.
 
 :::
 

--- a/docs/auth/permissions/tutorials/1-simple-user-permissions.mdx
+++ b/docs/auth/permissions/tutorials/1-simple-user-permissions.mdx
@@ -19,14 +19,14 @@ seoFrontMatterUpdated: false
 In this tutorial, you'll learn how to configure [permissions](/reference/metadata-reference/permissions.mdx) to limit
 users to accessing only their data.
 
-This can be done by passing a value in the header of each request to your application; Hasura will then use that value
-to return only the data which matches conditions you specify.
+This can be done by passing a value in the header of each request to your application; the query engine will then use
+that value to return only the data which matches conditions you specify.
 
 :::info Prerequisites
 
 Before continuing, ensure you have:
 
-- A local Hasura project.
+- A local PromptQL project.
 - Either JWT or Webhook mode enabled in your [AuthConfig](/reference/metadata-reference/auth-config.mdx).
 
 :::
@@ -36,7 +36,7 @@ Before continuing, ensure you have:
 ### Step 1. Create your ModelPermissions {#step-one}
 
 To create a new role, such as `user`, simply add the role to the list of `permissions` for the model to which you wish
-to limit access. Then, set up your access control rules.
+to limit access. Then, set up your access-control rules.
 
 In the example below, we'll allow users with the role of `user` to access only their own rows from a `Users` model by
 checking for a header value matching their `id`:
@@ -137,8 +137,8 @@ different roles and environments.
 
 ## Learn more about permissions and auth
 
-- [Permissions](/auth/permissions/index.mdx) with Hasura DDN
-- [Auth](/auth/overview.mdx) with Hasura DDN
+- [Permissions](/auth/permissions/index.mdx)
+- [Auth](/auth/overview.mdx)
 
 ## Similar tutorials
 

--- a/docs/auth/permissions/tutorials/index.mdx
+++ b/docs/auth/permissions/tutorials/index.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
 sidebar_label: Authorization
-description: "Learn how to create various access-control rules for your data sources with Hasura DDN."
+description: "Learn how to create various access-control rules for your data sources with PromptQL."
 keywords:
   - hasura
   - hasura ddn
@@ -16,10 +16,10 @@ seoFrontMatterUpdated: false
 ## Introduction
 
 In this section of tutorials, we'll provide step-by-step guides for common patterns in controlling users' access to data
-via your supergraph.
+via your metadata.
 
-If you're unfamiliar with how Hasura DDN handles authorization, [check out the docs](/auth/overview.mdx) before diving
-deeper into one of these tutorials.
+If you're unfamiliar with how the query engine handles authorization, [check out the docs](/auth/overview.mdx) before
+diving deeper into one of these tutorials.
 
 ## Recipes
 

--- a/docs/auth/permissions/type-permissions.mdx
+++ b/docs/auth/permissions/type-permissions.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-description: "Guide on defining Type Permissions for API fields in a supergraph."
+description: "Guide on defining Type Permissions for API fields in your metadata."
 keywords:
   - type permissions
   - supergraph roles
@@ -14,9 +14,9 @@ To make API **fields** available to a role, you define a `TypePermissions` objec
 
 You can think of TypePermissions as being similar to column-level permissions in a relational database. Just as you can
 restrict access to specific columns in a table based on the user's role, TypePermissions allow you to control access to
-specific fields in a type within your supergraph.
+specific fields in a type within your metadata.
 
-By default, whenever a new type is created in your supergraph, each field is defined as being only accessible to the
+By default, whenever a new type is created in your metadata, each field is defined as being only accessible to the
 `admin` role.
 
 To add a new role, add a new item to the `permissions` array in the TypePermissions object.

--- a/docs/auth/playground-auth.mdx
+++ b/docs/auth/playground-auth.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+title: Playground Auth
 description: "Learn how the PromptQL Playground interface sets the auth headers for your requests."
 keywords:
   - PromptQL Playground
@@ -13,7 +14,9 @@ import Thumbnail from "@site/src/components/Thumbnail";
 
 # PromptQL Playground Auth
 
-You can check the auth which the PromptQL Playground client is using by clicking the Auth button on the left-hand side
+## Introduction
+
+You can check the auth which the PromptQL Playground client is using by clicking the `Auth` button on the left-hand side
 of the chat dialogue.
 
 <Thumbnail src="/img/auth/piql-auth-button.png" alt="Authentication using JWT" />

--- a/docs/auth/webhook/index.mdx
+++ b/docs/auth/webhook/index.mdx
@@ -20,10 +20,10 @@ sidebar_label: Webhook
 
 ## Introduction
 
-You can configure Hasura DDN to use webhook mode in order to authenticate incoming requests.
+You can configure the query engine to use webhook mode in order to authenticate incoming requests.
 
-This requires specifying a URL - which Hasura calls with the original request headers - that then returns a body
-containing the session variables after authenticating the request.
+This requires specifying a URL - which the query engine will call with the original request headers - that then returns
+a body containing the session variables after authenticating the request.
 
 ## Webhook mode setup
 

--- a/docs/auth/webhook/webhook-mode.mdx
+++ b/docs/auth/webhook/webhook-mode.mdx
@@ -1,7 +1,5 @@
 ---
-description:
-  "Learn how to set up Hasura DDN and PromptQL with Webhook mode to authenticate requests and apply access-control
-  rules."
+description: "Learn how to set up PromptQL with Webhook mode to authenticate requests and apply access-control rules."
 keywords:
   - hasura webhook mode
   - hasura engine authentication
@@ -21,7 +19,7 @@ import Thumbnail from "@site/src/components/Thumbnail";
 
 ## Introduction
 
-You can enable Hasura DDN to use an auth webhook in just a few steps.
+You can enable the distributed query engine to use an auth webhook in just a few steps.
 
 You will need to provide a URL that your application will call with the original request headers, and it should return a
 body with the session variables after the request is authenticated.
@@ -33,7 +31,7 @@ body with the session variables after the request is authenticated.
 The only session variable required is `x-hasura-role` appearing in the response body.
 
 In contrast to JWT mode, you do not have to pass `x-hasura-allowed-roles` or `x-hasura-default-role` session variables
-and a `x-hasura-role` header will no be checked.
+and a `x-hasura-role` header will not be checked.
 
 Session variable keys are case-insensitive. Values are case-sensitive.
 
@@ -41,9 +39,9 @@ Session variable keys are case-insensitive. Values are case-sensitive.
 
 ## Step 1. Update your AuthConfig {#update-authconfig}
 
-Hasura utilizes an [AuthConfig](/reference/metadata-reference/auth-config.mdx) object that allows you to define the
-configuration for your authentication service. In a standard setup the `auth-config.hml` file can be found in your
-`globals` directory.
+Your application utilizes an [AuthConfig](/reference/metadata-reference/auth-config.mdx) object that allows you to
+define the configuration for your authentication service. In a standard setup the `auth-config.hml` file can be found in
+your `globals` directory.
 
 :::tip Hasura VS Code extension
 
@@ -82,10 +80,10 @@ AUTH_WEBHOOK_URL=http://auth_hook:3050/validate-request
 
 ### GET vs POST
 
-For a POST request, the headers received by Hasura on the query can be forwarded to the webhook in a JSON object in the
+For a POST request, the headers received by the query engine can be forwarded to the webhook in a JSON object in the
 body of the request under a `headers` key.
 
-For a GET request, the headers received by Hasura on the query can be forwarded to the webhook as actual headers on the
+For a GET request, the headers received by the query engine can be forwarded to the webhook as _actual headers_ on the
 request and the body will be empty.
 
 What we've provided above is a sample configuration as a POST request but it can be configured as a GET request. See the
@@ -107,7 +105,7 @@ Also, the webhook will receive the `user-agent` header as an actual header on th
 :::tip Environment variables
 
 You can use environment variables to dynamically and securely add the webhook URL to your AuthConfig. You can add these
-values to your root-level `.env` and then map them in the `globals` subgraph.yaml file. Alternatively, you can include
+values to your root-level `.env` and then map them in the `globals` `subgraph.yaml` file. Alternatively, you can include
 raw strings here using `value` instead of `valueFromEnv`.
 
 :::
@@ -155,8 +153,8 @@ can pass any headers you wish.
 
 :::tip Forward all headers
 
-If you want to forward all headers received by Hasura on the query to the webhook, you can set `forward: "*"`. This will
-forward all headers received by Hasura on the query to the webhook, excluding the ignored headers.
+If you want to forward all headers received by the query engine on the request to the webhook, you can set
+`forward: "*"`. This will forward all headers received by the engine, excluding the ignored headers.
 
 :::
 
@@ -179,16 +177,16 @@ a `401` status code (for an invalid or missing token).
 
 You should respond with session variables beginning with `X-Hasura-*` in an object in the **body** of your response. The
 value of each session variable can be any JSON value. These will be available to your
-[permissions](/reference/metadata-reference/permissions.mdx) in Hasura.
+[permissions](/reference/metadata-reference/permissions.mdx) defined in the application's metadata layer.
 
-You will, at least, need to set the `X-Hasura-Role` session variable to let the Hasura DDN know which role to use for
+You will, at least, need to set the `X-Hasura-Role` session variable to let the query engine know which role to use for
 this request. Unlike [JWT auth mode](auth/jwt/jwt-mode.mdx), you do not have to pass `X-Hasura-Allowed-Roles` or
 `X-Hasura-Default-Role` session variables.
 
 In the example below the `X-Hasura-Is-Owner` and `X-Hasura-Custom` are examples of custom session variables which can be
 used to enforce permissions in your application.
 
-```json title="Example response from your webhook to Hasura DDN"
+```json title="Example response from your webhook to the query engine:"
 HTTP/1.1 200 OK
 Content-Type: application/json
 
@@ -274,7 +272,7 @@ ddn supergraph build local
 Here we're making a request to our instance which will be validated by our webhook which returns a payload of session
 variables.
 
-```json title="Example response from our webhook to Hasura:"
+```json title="Example response from our webhook to the query engine:"
 {
   "x-hasura-user-id": "7cf0a66c-65b7-11ed-b904-fb49f034fbbb",
   "x-hasura-role": "user"

--- a/docs/business-logic/add-a-lambda-connector.mdx
+++ b/docs/business-logic/add-a-lambda-connector.mdx
@@ -24,9 +24,9 @@ import Prereqs from "@site/docs/_prereqs.mdx";
 You can use lambda connectors to give PromptQL abilities to execute custom business logic on behalf of the user. We can
 add a lamdba connector runtime in Node.js with **TypeScript**, **Python**, or **Go**, and expose functions to PromptQL
 as tools it can use. This means PromptQL isn't limited to querying data — it can **trigger logic**, **run workflows**,
-or **transform inputs into actions**, all within a secure and consistent API environment.
+or **transform inputs into actions & automations**, all within a secure and consistent API environment.
 
-By treating logic like a first-class data source, PromptQL ensures your application has a unified surface for
+By treating logic like a first-class data source, PromptQL ensures your application has a unified interface for
 interacting with databases, API services, and whatever actions you want your application to be able to take. You define
 how the system should respond to user queries, apply business rules, or even call third-party APIs.
 
@@ -103,8 +103,8 @@ The JSDoc comments are optional, but the first general comment is highly recomme
 function's purpose and parameters and will be added to the function's metadata.
 
 The `@readonly` tag indicates that the function does not modify any data, and PromptQL will be able to call this without
-asking for confirmation. Under the hood, DDN will create an NDC function for `@readonly` lambdas and an NDC procedure
-for functions that are not marked as `@readonly`.
+asking for confirmation. Under the hood, the connector will expose an NDC function for `@readonly` lambdas and an NDC
+procedure for functions that are not marked as `@readonly`.
 
 </TabItem>
 <TabItem value="Python" label="Python">

--- a/docs/business-logic/errors.mdx
+++ b/docs/business-logic/errors.mdx
@@ -49,7 +49,7 @@ the guide [here](/business-logic/dev-mode.mdx).
 
 ### Deployed connectors
 
-For deployed connectors, you can use the DDN CLI to locate the connector's build ID and then output the logs to your
+For deployed connectors, you can use the CLI to locate the connector's build ID and then output the logs to your
 terminal.
 
 #### Step 1. List all builds for a connector

--- a/docs/business-logic/lambda-connector-types.mdx
+++ b/docs/business-logic/lambda-connector-types.mdx
@@ -15,8 +15,9 @@ import TabItem from "@theme/TabItem";
 
 # Lambda Connector Types
 
-Lambda connectors written in TypeScript, Python, or Go can accept and return native types that map to NDC data model
-types. Below are examples of supported types in each language.
+Lambda connectors written in TypeScript, Python, or Go can accept and return native types that map to
+[NDC data model types](https://hasura.github.io/ndc-spec/specification/types.html). Below are examples of supported
+types in each language.
 
 For information about setting up your lambda connectors, see
 [Add a Lambda Connector](/business-logic/add-a-lambda-connector.mdx).

--- a/docs/business-logic/overview.mdx
+++ b/docs/business-logic/overview.mdx
@@ -17,7 +17,7 @@ keywords:
 You can use lambda connectors to give PromptQL abilities to execute custom business logic on behalf of the user. We can
 add a lamdba connector runtime in Node.js with **TypeScript**, **Python**, or **Go**, and expose functions to PromptQL
 as tools it can use. This means PromptQL isn't limited to querying data — it can **trigger logic**, **run workflows**,
-or **transform inputs into actions**.
+or **transform inputs into actions and automations**.
 
 - [Lambda Connector Basics](/business-logic/add-a-lambda-connector.mdx)
 - [Add Custom Environment Variables](/business-logic/add-env-vars-to-a-lambda.mdx)

--- a/docs/data-modeling/command.mdx
+++ b/docs/data-modeling/command.mdx
@@ -36,10 +36,10 @@ action taken.
 When setting up commands for use with PromptQL, follow this lifecycle:
 
 1. Have some operation in your data source that you want to make executable via PromptQL.
-2. Introspect your data source using the DDN CLI with the relevant data connector to fetch the operation resources.
-3. Add the command to your metadata with the DDN CLI.
-4. Create a build of your supergraph API with the DDN CLI.
-5. Serve your build as your API with the Hasura engine either locally or in the cloud.
+2. Introspect your data source using the CLI with the relevant data connector to fetch the operation resources.
+3. Add the command to your metadata with the CLI.
+4. Create a build with the CLI.
+5. Serve your build via the packaged distributed query engine, either locally or in the cloud.
 6. Interact with your data through PromptQL, which can now execute these commands as part of its dynamic query planning.
 
 <Thumbnail src="/img/data-modeling/ddn-cli-process.png" alt="Data modeling lifecycle" />
@@ -53,7 +53,7 @@ get to that point.
 ### From a source operation
 
 Some data connectors support the ability to introspect your data source to discover the commands that can be added to
-your supergraph automatically.
+your metadata layer automatically.
 
 ```ddn title="Introspect your data source:"
 ddn connector introspect <connector_name>

--- a/docs/data-modeling/iterate.mdx
+++ b/docs/data-modeling/iterate.mdx
@@ -16,8 +16,8 @@ toc_max_heading_level: 3
 
 ## Introduction
 
-After you've created a DDN supergraph to use with PromptQL, you'll often need to iterate on your data model — whether
-you're adding a new table, refining a command, or evolving your business logic.
+After first creating your semantic metadata layer to use with PromptQL, you'll often need to iterate on your underlying
+data models — whether you're adding a new table, refining a command, or evolving your business logic.
 
 This guide explains when and why you need to run `ddn supergraph build local` to ensure your changes are reflected in
 your API.
@@ -43,8 +43,8 @@ rebuilding.
 
 Whether your metadata changes are generated via the CLI or you've hand-authored a change (using the
 [VS Code extension](https://marketplace.visualstudio.com/items?itemName=HasuraHQ.hasura)), you'll need to create a new
-build of your application. This will ensure the JSON configuration files consumed by your Hasura Engine are updated with
-the latest changes.
+build of your application. This will ensure the JSON configuration files consumed by the distributed query engine are
+updated with the latest changes.
 
 ### You make changes to your underlying data model
 
@@ -53,7 +53,7 @@ MongoDB. You may have written new custom logic in TypeScript or want to import a
 Whatever it is, you will follow the same steps each time anything changes in your data source schema to iterate on your
 data model.
 
-#### Re-introspecting your data model
+#### Re-introspect your data model
 
 Re-introspecting your data model will update the connector configuration to reflect the changes in your data sources.
 
@@ -61,13 +61,13 @@ Re-introspecting your data model will update the connector configuration to refl
 ddn connector introspect my_connector
 ```
 
-#### Viewing resources
+#### View resources
 
 ```ddn title="You can then view the resources that have been discovered by running:"
 ddn connector show-resources my_connector
 ```
 
-#### Adding resources
+#### Add resources
 
 ```ddn title="And add precisely the resources you need running any of the following commands with real values:"
 ddn model add my_connector my_model
@@ -81,7 +81,7 @@ ddn command add my_connector "*"
 ddn relationship add my_connector "*"
 ```
 
-#### Adding semantic Information
+#### Add semantic Information
 
 It's highly recommended to provide extra natural language descriptions of the resources in your project so that the
 PromptQL can better understand your data and create appropriate query plans.
@@ -89,15 +89,15 @@ PromptQL can better understand your data and create appropriate query plans.
 The description field can be added to `Model`, `Command` and `Relationship` metadata elements to provide semantic
 context. See more about [semantic information here](/data-modeling/semantic-information.mdx).
 
-#### Building a new supergraph
+#### Rebuild
 
-```ddn title="You can then build a new local supergraph by running:"
+```ddn title="You can then create a new build:"
 ddn supergraph build local
 ```
 
 :::info Build for Hasura Cloud
 
-You can also build a new supergraph for a project on Hasura Cloud:
+You can also create a new build on Hasura Cloud:
 
 If you don't have a project on Hasura Cloud, you can create one by running:
 
@@ -113,7 +113,7 @@ ddn supergraph build create
 
 :::
 
-#### Restarting services locally
+#### Restart services locally
 
 If you are iterating locally, you then need to restart the Docker services by running:
 

--- a/docs/data-modeling/model.mdx
+++ b/docs/data-modeling/model.mdx
@@ -29,13 +29,13 @@ semantic understanding PromptQL needs to generate precise query plans and produc
 
 ## Lifecycle
 
-Creating models for your PromptQL supergraph involves the following steps:
+Creating models for your PromptQL's metadata layer involves the following steps:
 
 1. Identify data sources that you want PromptQL to intelligently interact with.
-2. Introspect your data source using the DDN CLI with the relevant data connector to fetch the entity resources.
-3. Add the model to your metadata with the DDN CLI.
-4. Create a build of your supergraph with the DDN CLI.
-5. Serve your build with the Hasura engine either locally or in the cloud.
+2. Introspect your data source using the CLI with the relevant data connector to fetch the entity resources.
+3. Add the model to your metadata with the CLI.
+4. Create a build of your application with the CLI.
+5. Serve your build via the packaged distributed query engine, either locally or in the cloud.
 6. Interact with your data through PromptQL in a natural, conversational way.
 
 <Thumbnail src="/img/data-modeling/ddn-cli-process.png" alt="Data modeling lifecycle" />
@@ -58,24 +58,19 @@ Whenever you update your data source, you can run the above command to fetch the
 ddn connector show-resources <connector_name>
 ```
 
-This is an optional step and will output a list of resources that DDN discovered in your data source in the previous
-step.
-
-```ddn
+```ddn title="This optional step will output a list of resources that the connector discovered in your data source:"
 ddn model add <connector_link_name> <collection_name>
 ```
 
-Or you can optionally add all the models by specifying `"*"`.
-
-```ddn
+```ddn title="Or you can optionally add all the models using this wildcard:"
 ddn model add <connector_link_name> "*"
 ```
 
 This will add models with their accompanying metadata definitions to your metadata.
 
-You can now build your supergraph, serve it, and begin having meaningful conversations with your data through PromptQL.
-With robust models in place, PromptQL can create dynamic query plans that accurately address your requests and provide
-deep insights into your data.
+You can now create a build, serve it, and begin having meaningful conversations with your data through PromptQL. With
+robust models in place, PromptQL can create dynamic query plans that accurately address your requests and provide deep
+insights into your data.
 
 :::info Context for CLI commands
 
@@ -100,8 +95,8 @@ ddn model update <connector_link_name> <model_name>
 
 You will see an output which explains how new resources were added or updated in the model.
 
-You can now build your supergraph, serve it, and continue interacting with your data using PromptQL, which will
-automatically adjust its query plans based on the updated model definitions.
+You can now create a build, serve it, and continue interacting with your data using PromptQL, which will automatically
+adjust its query plans based on the updated model definitions.
 
 You can also update the model by editing the metadata manually.
 
@@ -125,7 +120,7 @@ The way this is done is via a `Relationship`. Read more about
 ddn model remove users
 ```
 
-In addition to removing the `Model` object itself, the DDN CLI will also remove the associated metadata definitions.
+In addition to removing the `Model` object itself, the CLI will also remove the associated metadata definitions.
 
 ## Reference
 

--- a/docs/data-modeling/overview.mdx
+++ b/docs/data-modeling/overview.mdx
@@ -19,22 +19,17 @@ import Thumbnail from "@site/src/components/Thumbnail";
 
 ## Introduction
 
-To power PromptQL, Hasura DDN defines your API schema declaratively. An approach that centralizes all your data
-collections, operations, relationships, and permissions in one place. This makes it easy to organize, modify, secure,
-reason about, and grow the schema which represents your API which is is accessed via PromptQL.
+Your PromptQL application is powered by an agentic semantic metadata layer. This approach centralizes all your data
+collections, operations, relationships, and permissions in one place. This makes it easy for your (and PromptQL) to
+organize, modify, secure, reason about, and grow the schema which represents your API.
 
 ## Lifecycle
 
-PromptQL uses Hasura DDN to define your API schema.
+PromptQL uses this semantic metadata layer to define your API schema:
 
-Hasura DDN uses data connectors to connect to your data sources.
-
-Data connectors introspect the source to understand the source schema.
-
-The DDN CLI uses the introspection results to generate the API schema metadata objects. This can also be done manually.
-
-The metadata is then "built" by the DDN CLI into a format which the Hasura engine can use to provide information to
-PromptQL.
+- Data connectors link to your data sources and introspect the source schema.
+- The CLI then uses the introspection results to generate metadata objects.
+- The metadata is "built" by the CLI into a format that the engine service uses to power PromptQL's interactions.
 
 <Thumbnail src="/img/data-modeling/ddn-cli-process.png" alt="Data modeling lifecycle" width="1000px" />
 

--- a/docs/data-modeling/partials/lambda-connectors/go/_command-create-native-operation-how-to.mdx
+++ b/docs/data-modeling/partials/lambda-connectors/go/_command-create-native-operation-how-to.mdx
@@ -33,11 +33,11 @@ func ProcedureCustomCode(ctx context.Context, state *types.State, arguments *Inp
 }
 ```
 
-Using the prefix `Procedure` ensures ProcedureCustomCode() is exposed as a mutation in your supergraph. Prefixing with
+Using the prefix `Procedure` ensures ProcedureCustomCode() is exposed as a mutation in your metadata. Prefixing with
 `Function` identifies it as a function to be exposed as a query. Both will be accessible through PromptQL.
 
 Both have typed input arguments and return strings, which the connector will use to generate the corresponding schema
-for your supergraph.
+for your metadata.
 
 ```ddn title="Introspect the connector:"
 ddn connector introspect my_go

--- a/docs/data-modeling/partials/lambda-connectors/python/_command-create-native-operation-how-to.mdx
+++ b/docs/data-modeling/partials/lambda-connectors/python/_command-create-native-operation-how-to.mdx
@@ -1,5 +1,5 @@
-You can create Python connectors with custom code to enhance PromptQL's ability to talk to all your data. These
-connectors become available in your supergraph, allowing PromptQL to include them in its dynamic query plans.
+You can create Python connectors with custom code to enhance PromptQL's ability to talk to all your data. These commands
+become available in your application, allowing PromptQL to include them in its dynamic query plans.
 
 ```ddn title="Initialize a new connector and select hasura/python from the list:"
 ddn connector init my_py -i
@@ -50,5 +50,5 @@ query MyCustomCode {
 }
 ```
 
-By extending your supergraph with custom Python connectors, you give PromptQL the ability to perform specialized
+By extending your application with custom Python connectors, you give PromptQL the ability to perform specialized
 operations that go beyond standard data access, enabling more powerful and flexible interactions with your data.

--- a/docs/data-modeling/partials/lambda-connectors/typescript/_command-create-native-operation-how-to.mdx
+++ b/docs/data-modeling/partials/lambda-connectors/typescript/_command-create-native-operation-how-to.mdx
@@ -40,5 +40,5 @@ ddn console --local
 
 Once set up, you can interact with your custom function through PromptQL conversations.
 
-By adding custom functions to your supergraph, you extend PromptQL's capabilities to talk to your data in ways specific
+By adding custom functions to your application, you extend PromptQL's capabilities to talk to your data in ways specific
 to your business needs.

--- a/docs/data-modeling/permissions.mdx
+++ b/docs/data-modeling/permissions.mdx
@@ -19,17 +19,17 @@ Permissions keep data secure by allowing you to control what data can be accesse
 which user roles. This ensures that when users talk to their data using PromptQL, they only see the information they're
 authorized to access.
 
-When an authentication mode is enabled, the Hasura engine will look for session variables on every PromptQL request, it
-can then use permissions defined in metadata and the session variables to determine if the request is allowed to
-proceed.
+When an authentication mode is enabled, the distributed query engine will look for session variables on every PromptQL
+request, it can then use permissions defined in metadata and the session variables to determine if the request is
+allowed to proceed.
 
 ## Lifecycle
 
-Hasura DDN uses Role Based Access Control (RBAC) to determine which user roles can access which data in your supergraph
+Role Based Access Control (RBAC) rules in your metadata are used to determine which user roles can access which data
 when interacting with PromptQL.
 
-The DDN CLI will automatically create permissions for your models and commands when they are added to your metadata for
-only the `admin` role by default.
+The CLI will automatically create permissions for your models and commands when they are added to your metadata for only
+the `admin` role by default.
 
 All other permissions for all other user roles must be added manually.
 

--- a/docs/data-modeling/relationship.mdx
+++ b/docs/data-modeling/relationship.mdx
@@ -38,13 +38,13 @@ be in the same subgraph.
 
 ## Lifecycle
 
-Many relationships can be created automatically by the DDN CLI from detected underlying connections such as foreign
-keys. In such cases the lifecycle in creating a relationship in your metadata is as follows:
+Many relationships can be created automatically by the CLI from detected underlying connections such as foreign keys. In
+such cases the lifecycle in creating a relationship in your metadata is as follows:
 
-1. Introspect your data source using the DDN CLI with the relevant data connector to fetch the entity resources.
-2. Add the detected relationships to your metadata with the DDN CLI.
-3. Create a build of your supergraph API with the DDN CLI.
-4. Serve your build to enable PromptQL to access your data with the Hasura engine either locally or in the cloud.
+1. Introspect your data source using the CLI with the relevant data connector to fetch the entity resources.
+2. Add the detected relationships to your metadata with the CLI.
+3. Create a build with the CLI.
+4. Serve your build via the packaged distributed query engine, either locally or in the cloud.
 5. Iterate on your PromptQL experience by repeating this process or by editing your metadata manually as needed.
 
 <Thumbnail src="/img/data-modeling/ddn-cli-process.png" alt="Data modeling lifecycle" width="1000px" />
@@ -63,10 +63,10 @@ commands.
 The target command can be enabled with a custom piece of business logic on a lambda data connector, or a native mutation
 operation.
 
-### Using the DDN CLI
+### Using the CLI
 
-The DDN CLI and your data connectors will detect many relationships in your data sources automatically, for instance
-from foreign keys in a relational database, and once introspected, you can add them to your metadata.
+The CLI and your data connectors will detect many relationships in your data sources automatically, for instance from
+foreign keys in a relational database, and once introspected, you can add them to your metadata.
 
 ```ddn title="Introspect your data source:"
 ddn connector introspect <connector_name>
@@ -90,7 +90,7 @@ ddn relationship add <connector_link_name> "*"
 
 Note that the above CLI commands work without also adding the relevant subgraph to the command with the `--subgraph`
 flag because this has been set in the CLI context. You can learn more about creating and switching contexts in the
-[CLI context](/) section. {/* TODO: Add link */}
+[CLI context](/project-configuration/project-management/manage-contexts.mdx) section.
 
 :::
 
@@ -153,7 +153,7 @@ ddn connector introspect <connector_name>
 ddn model update <connector_name> <model_name>
 ```
 
-Now, you can either delete the existing `Relationship` object and use the DDN CLI to add it again:
+Now, you can either delete the existing `Relationship` object and use the CLI to add it again:
 
 ```ddn title="Delete your existing relationship manually and add it again:"
 ddn relationship add <connector_link_name> <collection_name>

--- a/docs/data-modeling/semantic-information.mdx
+++ b/docs/data-modeling/semantic-information.mdx
@@ -5,9 +5,9 @@ description: "Add additional semantic information to DDN project metadata using 
 
 # Semantic Information in PromptQL
 
-PromptQL uses Hasura DDN project metadata to understand your data model and create appropriate query plans. While the
-basic metadata provides structural information, adding semantic descriptions helps the LLM better understand the context
-and purpose of your data model elements.
+PromptQL uses an agentic semantic metadata layer to understand your data model and create appropriate query plans. While
+the basic metadata provides structural information, adding semantic descriptions helps the LLM better understand the
+context and purpose of your data model elements.
 
 ## Overview
 

--- a/docs/data-sources/connect-to-a-source.mdx
+++ b/docs/data-sources/connect-to-a-source.mdx
@@ -128,5 +128,7 @@ directory of the subgraph where you added the connector (default: `app`). Finall
 ## Next steps
 
 Now that you've initialized a connector and connected it to your data, you're ready to introspect the source and
-populate the configuration files with source-specific information that Hasura will need to build your application. Check
-out the [introspection page](/data-sources/introspect-a-source.mdx) to learn more.
+populate the configuration files with source-specific information that PromptQL will need to build your agentic semantic
+metadata layer.
+
+Check out the [introspection page](/data-sources/introspect-a-source.mdx) to learn more.

--- a/docs/data-sources/introspect-a-source.mdx
+++ b/docs/data-sources/introspect-a-source.mdx
@@ -15,7 +15,7 @@ keywords:
 ## Introduction
 
 This guide explains how to use a connector to introspect a data source. After introspection, you'll be ready to begin
-generating Hasura metadata that represents resources (such as tables or collections) in your data source.
+generating metadata that represents resources (such as tables or collections) in your data source.
 
 This metadata will act as the blueprint for your application and will empower PromptQL with the structure it needs to
 understand your data, generate accurate responses, and take meaningful action.
@@ -47,16 +47,16 @@ two files, both located in your connector's directory:
 
 :::info When to use this command
 
-This command will be used at least once with every connector; Hasura **must** introspect your data source in order to
-understand the resources that are present.
+This command will be used at least once with every connector; the connector **must** introspect your data source in
+order to understand the resources that are present.
 
-**Additionally, any time you modify your source schema, you should re-run this command to ensure your Hasura metadata is
+**Additionally, any time you modify your source schema, you should re-run this command to ensure your metadata is
 up-to-date with your source schema.**
 
 :::
 
 ## Next steps
 
-With your source introspected and the configuration files populated, you can now start creating Hasura metadata that
-will represent your source's schema in your application. Check out the [Data Modeling](/data-modeling/overview.mdx)
-section to begin creating models, commands, and relationships for your data.
+With your source introspected and the configuration files populated, you can now start adding this information to your
+agentic semantic metadata layer. Check out the [Data Modeling](/data-modeling/overview.mdx) section to begin creating
+models, commands, and relationships for your data.

--- a/docs/data-sources/overview.mdx
+++ b/docs/data-sources/overview.mdx
@@ -14,7 +14,7 @@ keywords:
 
 ## What is a data source?
 
-In PromptQL, a data source is anything you can ask questions about.
+In PromptQL, a data source is anything that can provide data in response to a question.
 
 That includes traditional databases like Postgres and MySQL, but also REST APIs, GraphQL endpoints, and even custom
 functions or services. If it returns data, it can be a data source.
@@ -31,7 +31,7 @@ result.
 You don't need to worry about where the data lives — PromptQL can traverse across your connected sources to answer your
 question.
 
-You can get started by choosing one of the supported connectors:
+You can get started by [choosing one of the supported connectors](/data-sources/connect-to-a-source.mdx):
 
 - Amazon Athena
 - Amazon Redshift

--- a/docs/data-sources/troubleshooting.mdx
+++ b/docs/data-sources/troubleshooting.mdx
@@ -31,9 +31,9 @@ addresses. You can do this by adding the following to your allowlist:
 
 #### Docker networking issues
 
-Hasura DDN resolves `local.hasura.dev` to your machine's `localhost`. This avoids Docker networking conflicts, where
-`localhost` might point to your source's container instead of your local machine. To fix this, update any `localhost`
-references in your connection strings to `local.hasura.dev`.
+We resolve `local.hasura.dev` to your machine's `localhost`. This avoids Docker networking conflicts, where `localhost`
+might point to your source's container instead of your local machine. To fix this, update any `localhost` references in
+your connection strings to `local.hasura.dev`.
 
 ### My connector won't introspect my data source
 
@@ -67,7 +67,7 @@ kill it and then try initializing the connector again.
 ### My connector isn't reflecting schema changes in my data source
 
 You may have not re-run the introspection steps. Remember, each time your data source's schema changes, you'll need to
-re-run this command to make Hasura DDN aware of the new schema. Follow the guide
+re-run this command to make your connector aware of the new schema. Follow the guide
 [here](/data-sources/introspect-a-source.mdx).
 
 ### My connector isn't reflecting schema changes in my application

--- a/docs/help/glossary.mdx
+++ b/docs/help/glossary.mdx
@@ -38,9 +38,9 @@ generates and runs programs that compose tool calls and LLM tasks, providing:
 - Detailed execution plans for complete explainability
 - Fine-grained authorization to protect sensitive data
 
-PromptQL uses Hasura DDN's data layer which provides out-of-the-box connectors to a wide range of data sources,
-introspecting your data and helping you build a high-quality realtime data product with semantic metadata and
-fine-grained entitlements.
+PromptQL uses a semantic metadata layer which utilizes out-of-the-box connectors to access a wide range of data sources,
+introspect your data and help you build a high-quality realtime data product with declarative metadata and fine-grained
+entitlements.
 
 ## Hasura Data Delivery Network (DDN)
 
@@ -97,12 +97,12 @@ The data plane manages the actual handling of application requests and responses
 application operations, the transmission of data between clients and endpoints, and the processing of data payloads. The
 following are the main components of a data plane:
 
-**Hasura v3 GraphQL Engine:** The engine takes in an API request (e.g., a question for PromptQL), converts it into an
+**Distributed Query Engine:** The engine takes in an API request (e.g., a question for PromptQL), converts it into an
 intermediate representation that the connectors can handle, and creates a plan for the query execution across various
 data sources.
 
-**Hasura connectors:** These handle the actual API execution. They accept the intermediate representation from the
-engine and use the most efficient mechanism to execute the query and fetch/mutate data from the underlying data source.
+**Data Connectors:** These handle the actual API execution. They accept the intermediate representation from the engine
+and use the most efficient mechanism to execute the query and fetch/mutate data from the underlying data source.
 
 ## Supergraph
 
@@ -142,10 +142,10 @@ your conversations correctly.
 
 By default, these objects live in the `globals` subgraph, but you can move them to another subgraph if needed.
 
-## Hasura metadata
+## Agentic Semantic Metadata Layer
 
-Hasura metadata defines the structure of your supergraph; it gives PromptQL the context it needs to ask the right
-questions, enforce permissions, and return meaningful answers.
+Metadata defines the structure of your supergraph; it gives PromptQL the context it needs to ask the right questions,
+enforce permissions, and return meaningful answers.
 
 Metadata is written declaratively and describes how to connect to your data sources, what the API should look like, and
 how different parts of your system relate to each other. It introduces key modeling constructs such as `Types`,
@@ -159,7 +159,7 @@ full control over how the application behaves.
 
 ## .hml (Hasura Metadata Language)
 
-`.hml` is the file extension used for writing Hasura metadata. It shares the same syntax as `.yaml`, and offers the same
+`.hml` is the file extension used for writing metadata. It shares the same syntax as `.yaml`, and offers the same
 benefits: it's readable, supports nested data structures, allows for inline comments, and is portable across
 environments and teams.
 
@@ -186,14 +186,14 @@ something goes wrong, you can roll back just as easily.
 
 ## Data Sources
 
-Any external data source, database, or service that can be connected to Hasura DDN using a Data Connector agent.
+Any external data source, database, or service that can be integrated into your application using a data connector.
 
 [Learn more](/reference/metadata-reference/data-connector-links.mdx).
 
 ## Native Data Connector Specification (NDC Spec)
 
-A standardized specification that allows you to extend the functionality of the Hasura server by providing web services
-that resolve new sources of data and business logic and help define the metadata structure for APIs in Hasura DDN. The
+A standardized specification that allows you to extend the functionality of the query engine by providing web services
+that resolve new sources of data and business logic and help define the metadata structure for APIs in your project. The
 specification defines types such as `collections`, `functions`, and `procedures` that help in describing the behavior of
 agents or connectors that connect to the underlying data source. It provides a framework and guidelines on the types of
 web service endpoints that a connector needs to implement.
@@ -202,10 +202,11 @@ web service endpoints that a connector needs to implement.
 
 ## Native Data Connectors
 
-Data connectors are specialized agents that connect subgraphs to data sources, enabling communication in the data
+Data connectors are specialized servers that connect subgraphs to data sources, enabling communication in the data
 source's native language.
 
-They integrate Hasura with various external data sources and services based on the native data connector specification.
+They integrate your application with various external data sources and services based on the native data connector
+specification.
 
 Each subgraph can have multiple data connectors, and the same data source can be connected to different subgraphs via
 separate connector instances - allowing teams to work with the same source from different domain perspectives.
@@ -218,14 +219,13 @@ data sources.
 
 ## Push-Down Capabilities
 
-The ability in Hasura DDN to delegate certain query operations including Authorization to the underlying data source.
-This can improve query optimization and performance and is the reason why data connectors in Hasura DDN are called
-'native'.
+The ability for the query engine to delegate certain query operations (including authorization) to the underlying data
+source. This can improve query optimization and performance and is the reason why data connectors are called 'native'.
 
 ## Connector Hub
 
 Refers to the public site where all Native Data Connectors for Hasura DDN are listed. Users can discover connectors, get
-more information about their specific features and find documentation on how to use each connector with Hasura DDN.
+more information about their specific features and find documentation on how to use each connector with a project.
 
 [Learn more](https://hasura.io/connectors/).
 
@@ -271,13 +271,14 @@ validation as you author metadata.
 
 ## Authorization Permissions
 
-Authentication is managed at the supergraph level in Hasura DDN as defined by the `AuthConfig` object and cannot be
-customized at the subgraph level.
+Authentication is managed at the supergraph level as defined by the `AuthConfig` object and cannot be customized at the
+subgraph level.
 
-Authorization however, which is a metadata object in Hasura DDN that defines the access control or authorization rules
-on models and commands. [Learn more](/reference/metadata-reference/permissions.mdx), is managed at the subgraph level in
-Hasura DDN. This means that the permissions for models and commands are defined within the context of those objects in
-their respective subgraphs, and do not affect other subgraphs.
+Authorization however, is controlled via metadata objects that defines the access control or authorization rules on
+models and commands. [Learn more](/reference/metadata-reference/permissions.mdx)
+
+This is managed at the subgraph level in your project. This means that the permissions for models and commands are
+defined within the context of those objects in their respective subgraphs, and do not affect other subgraphs.
 
 Authorization rules in one subgraph can also be defined to reference data in a foreign subgraph even if that subgraph is
 in another repository.
@@ -290,7 +291,7 @@ querying capabilities.
 Each collection is defined by its name, any collection arguments (need to parametrize the collections), the object type
 (a collection of fields) of its rows, and some additional metadata related to constraints.
 
-Tracking a collection results in the creation of a 'model' object in Hasura metadata.
+Tracking a collection results in the creation of a 'model' object in metadata.
 
 [Learn more](https://hasura.github.io/ndc-spec/specification/schema/collections.html).
 
@@ -300,7 +301,7 @@ A function is a Native Data Connector Specification object that can be invoked w
 doesn't have side-effects and is thus "read only". Unlike collections, functions do not describe constraints and do not
 have object types.
 
-Tracking a function results in the creation of a `Command` Supergraph object in Hasura metadata.
+Tracking a function results in the creation of a `Command` Supergraph object in metadata.
 
 [Learn more](https://hasura.github.io/ndc-spec/specification/schema/functions.html).
 
@@ -309,51 +310,52 @@ Tracking a function results in the creation of a `Command` Supergraph object in 
 A procedure is a native data connector specification object, and it defines an action that the data connector implements
 and can mutate data and have other side-effects. Each procedure has arguments and a return type.
 
-Tracking a procedure results in the creation of a `Command` object in Hasura metadata.
+Tracking a procedure results in the creation of a `Command` object in metadata.
 
 [Learn more](https://hasura.github.io/ndc-spec/specification/schema/procedures.html).
 
 ## Supergraph config
 
-Supergraph config tells Hasura DDN how to construct your supergraph. A config will contain information such as which
-subgraphs to include and which resources to use for the build.
+The supergraph config tells the metadata build service (which we take care of running for you and refer to as **MBS**)
+how to construct your supergraph. A config will contain information such as which subgraphs to include and which
+resources to use for the build.
 
 [Learn more](/project-configuration/overview.mdx).
 
 ## Connector config
 
-Connector config tells Hasura DDN how to build your connector. It will contain information such as the type of connector
-and the location to the context files needed to build the connector.
+The connector config tells the MBS how to build your connector. It will contain information such as the type of
+connector and the location to the context files needed to build the connector.
 
 [Learn more](/project-configuration/overview.mdx).
 
 ## DDN CLI (Command-Line Interface)
 
-A tool in Hasura DDN that enables developers to interact with DDN from the command line. It supports various commands
-for creating builds, tracking objects, and deploying projects.
+A tool that enables developers to interact with Hasura DDN from the command line and manage local projects. It supports
+various commands for creating builds, tracking objects, and deploying projects.
 
 [Learn more](/reference/cli/index.mdx).
 
 ## VS Code Extension
 
-The Hasura VS Code extension enables features like inline validation of Hasura DDN metadata without having to create
-builds, code scaffolding snippets which can be used to quickly scaffold DDN metadata objects, intelligent autocomplete
-which shows autocomplete suggestions based on the current state of the DDN project, and other features like
-go-to-definition for inter-related DDN metadata objects, documentation on hover of any DDN metadata object, a project
-tree on sidebar which shows all DDN projects and metadata objects present in the currently opened folder.
+The Hasura VS Code extension enables features like inline validation of metadata without having to create builds, code
+scaffolding snippets which can be used to quickly scaffold DDN metadata objects, intelligent autocomplete which shows
+autocomplete suggestions based on the current state of the DDN project, and other features like go-to-definition for
+inter-related metadata objects, documentation on hover of any metadata object, a project tree on sidebar which shows all
+DDN projects and metadata objects present in the currently opened folder.
 
-It is strongly recommended to download the VS code extension while working with DDN projects, it can be downloaded from
-the [VS Code extension marketplace](https://marketplace.visualstudio.com/items?itemName=HasuraHQ.hasura).
+It is strongly recommended to use the VS code extension and can be downloaded from the
+[VS Code extension marketplace](https://marketplace.visualstudio.com/items?itemName=HasuraHQ.hasura).
 
-## Metadata build service
+## Metadata Build Service (MBS)
 
-Creates builds from the metadata and makes it available to Hasura v3 GraphQL Engine at the edge for it to serve the
-application. Provides essential error handling for fast debugging and troubleshooting.
+MBS creates builds from your metadata and makes it available to the distributed query engine at the edge for it to serve
+the application. Provides essential error handling for fast debugging and troubleshooting.
 
 ## Control plane cloud API
 
 This component is the underlying cloud service, which enables creating builds, applying builds and testing your API. We
-consider this the brain of DDN Console and CLI – the component that drives most of the DX functionalities.
+consider this the brain of the Hasura DDN Console and CLI – the component that drives most of the DX functionalities.
 
 ## PromptQL Console and Playground
 

--- a/docs/help/overview.mdx
+++ b/docs/help/overview.mdx
@@ -28,9 +28,10 @@ enhance how PromptQL interacts with your data.
 
 ### Ask the community
 
-- We have a forum where you can ask questions and get help from the community and Hasura employees. [Join here](#).
+- We have a forum where you can ask questions and get help from the community and Hasura employees.
+  [Join here](https://forum.hasura.io).
 - Additionally, you can create a GitHub issue for any bugs or feature requests
-  [here](https://github.com/hasura/promptql/issues).
+  [here](https://github.com/hasura/promptql-bug-tracker/issues/new/choose).
 
 ## Enterprise clients
 

--- a/docs/how-to-build-with-promptql/_boilerplateInit.mdx
+++ b/docs/how-to-build-with-promptql/_boilerplateInit.mdx
@@ -1,11 +1,11 @@
 ### Step 1. Authenticate your CLI
 
-```ddn title="Before you can create a new Hasura DDN project for PromptQL, you need to authenticate your CLI:"
+```ddn title="Before you can create a new PromptQL project, you need to authenticate your CLI:"
 ddn auth login
 ```
 
-This will launch a browser window prompting you to log in or sign up for Hasura DDN. After you log in, the CLI will
-acknowledge your login, giving you access to Hasura Cloud resources.
+This will launch a browser window prompting you to log in or sign up for Hasura DDN, our cloud provider. After you log
+in, the CLI will acknowledge your login, giving you access to Hasura DDN resources.
 
 ### Step 2. Scaffold out a new local project
 

--- a/docs/how-to-build-with-promptql/_boilerplateOverview.mdx
+++ b/docs/how-to-build-with-promptql/_boilerplateOverview.mdx
@@ -2,10 +2,10 @@
 
 This tutorial takes about {props.time} minutes to complete. You'll learn how to:
 
-- Set up a new Hasura DDN project to use with PromptQL
+- Set up a new PromptQL project
 - Connect it to {props.dataSourceName}
-- Generate Hasura metadata
+- Generate your agentic semantic metadata layer
 - Create a build
-- Run your first query with PromptQL
+- Talk to PromptQL
 
-Additionally, we'll familiarize you with the steps and workflows necessary to iterate on your data source.
+Additionally, we'll familiarize you with the steps and workflows necessary to iterate on your metadata.

--- a/docs/how-to-build-with-promptql/_boilerplateSummary.mdx
+++ b/docs/how-to-build-with-promptql/_boilerplateSummary.mdx
@@ -1,11 +1,12 @@
 ## Next steps
 
-Congratulations on completing your first Hasura PromptQL project with {props.dataSourceName}! 🎉
+Congratulations on completing your first PromptQL project with {props.dataSourceName}! 🎉
 
 Here's what you just accomplished:
 
 - You started with a fresh project and connected it to {props.dataSourceName}.
-- You set up metadata to represent your database schema, which acts as the blueprint for PromptQL.
+- You set up the agentic metadata layer to represent your data source's schema, which acts as the blueprint for
+  PromptQL.
 - Then, you created a build — essentially compiling everything into a ready-to-use structure — and successfully ran your
   first PromptQL queries to learn about your data.
 

--- a/docs/how-to-build-with-promptql/overview.mdx
+++ b/docs/how-to-build-with-promptql/overview.mdx
@@ -23,7 +23,8 @@ PromptQL, powered by Hasura DDN, makes it simple to build AI-ready APIs on your 
 You'll connect your data using **native connectors**, configure your API using **Hasura Metadata Language (HML)**, and
 create an immutable **build** that will serve your application.
 
-Then, you'll use the **PromptQL Playground UI**, or the **PromptQL API** to talk to your data.
+Then, you'll use the **PromptQL Playground UI** or the **PromptQL API** to chat with your data, ask questions, or
+automate tasks — just like you would with a trusted analyst or engineer who speaks your business’ language.
 
 ## Let's build something
 
@@ -37,7 +38,7 @@ you want to include:
 :::info Mix and match
 
 Keep in mind: these are simply broad buckets for you to get started. Any sources we support can be added to the same
-project to create a unified supergraph which feeds data to PromptQL.
+project to create a **unified agentic semantic metadata** layer which feeds data to PromptQL.
 
 :::
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -38,14 +38,13 @@ import DemoGallery from "@site/src/components/DemoGallery";
 
 <div className={'front-matter'}>
   <div>
-    Talk to your all your data accurately with natural language. 
-    
-    PromptQL is a novel agent approach to enable high-trust LLM interaction with business data & systems. It composes 
-    tool calls and LLM tasks in a way that provides a high degree of explainability, accuracy and repeatability, for 
-    arbitrarily complex tasks.
+    Talk to all your data using natural language, with the accuracy and reliability of a human expert.
 
-    PromptQL's data layer ([Hasura DDN](https://hasura.io/docs)) comes with out of the box connectors to a wide range of data sources. These
-    connectors introspect your data sources and code and help you build a high-quality realtime data product.
+    [PromptQL](https://promptql.io) is an AI platform that can map and translate all your business' connected data sources into a
+    language that LLMs can understand and act on <b>deterministically</b>. No more hallucinations, no more guessing.
+
+    Answer deep questions or build new automations to unlock insights your employees and customers can rely on.
+    Instantly. Reliably. Accurately.
 
   </div>
   <div className={'video-wrapper'}>

--- a/docs/observability/overview.mdx
+++ b/docs/observability/overview.mdx
@@ -12,7 +12,7 @@ keywords:
 
 # Observability
 
-Observability in Hasura DDN provides deep insights into your application's performance, user interactions, and system
+Observability with PromptQL provides deep insights into your application's performance, user interactions, and system
 health. These features help you understand how your applications are being used, identify performance bottlenecks, and
 troubleshoot issues effectively.
 

--- a/docs/project-configuration/overview.mdx
+++ b/docs/project-configuration/overview.mdx
@@ -16,10 +16,10 @@ keywords:
 
 ## Introduction
 
-A **project** in PromptQL is the foundation for building and managing your application. This foundational layer is known
-as the **Hasura DDN (Data Delivery Network)** and contains a structured collection of metadata files that define the
-behavior, relationships, and permissions for your application. These metadata files can be organized into **subgraphs**,
-each representing a distinct data domain.
+A **project** in PromptQL forms the backbone for building and managing your application. It contains a semantic
+collection of metadata objects that define the behavior, relationships, and permissions of your application. We
+sometimes refer to this as the **supergraph**. You can organize the files containing these metadata objects into
+**subgraphs**, with each subgraph representing a distinct data domain.
 
 Projects are designed to support both local development and cloud deployment. During development, you work with a local
 version of your project, which is linked to a cloud project through a
@@ -52,12 +52,12 @@ maintain robust applications efficiently.
 PromptQL also supports multi-repository setups, giving teams greater autonomy in their development process. With this
 setup:
 
-- Each team can maintain their **subgraph** in a separate repository while still contributing to the shared
-  **supergraph**.
+- Each team can maintain their metadata in a separate repository while still contributing to the shared semantic
+  metadata layer.
 - Teams can develop, test, and deploy their subgraphs independently, enabling faster iteration and minimizing
   dependencies on other teams.
-- The supergraph integrates these subgraphs into a single application, ensuring that the overall application remains
-  consistent and cohesive.
+- The query engine integrates these subgraphs into a single metadata layer, ensuring that the overall application
+  remains consistent and cohesive.
 
 This approach is ideal for large organizations where multiple teams work on distinct data domains but need to
 collaborate through a unified API. For more information, check out

--- a/docs/project-configuration/project-management/console-collaborator-comments.mdx
+++ b/docs/project-configuration/project-management/console-collaborator-comments.mdx
@@ -17,7 +17,7 @@ import Thumbnail from "@site/src/components/Thumbnail";
 
 ## Introduction
 
-Hasura provides a commenting feature that allows your data teams to start conversations directly on the supergraph
+Hasura DDN provides a commenting feature that allows your data teams to start conversations directly on the supergraph
 metadata. This feature enhances collaboration by closing the feedback loop and helps teams communicate more effectively
 about about their supergraph design and implementation.
 

--- a/docs/project-configuration/project-management/manage-collaborators.mdx
+++ b/docs/project-configuration/project-management/manage-collaborators.mdx
@@ -18,7 +18,7 @@ import Permissions from "@site/docs/project-configuration/_permissions.mdx";
 
 ## Introduction
 
-Hasura allows multiple users and teams to work together as collaborators on projects by assigning each user specific
+Hasura DDN allows multiple users and teams to work together as collaborators on projects by assigning each user specific
 roles and permissions.
 
 You can [invite users](#invite-collaborators) to a project, or allow users to [request access](#request-access).

--- a/docs/project-configuration/project-management/manage-contexts.mdx
+++ b/docs/project-configuration/project-management/manage-contexts.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
 sidebar_label: Manage project contexts
-description: "Learn how to manage contexts in a Hasura DDN project."
+description: "Learn how to manage contexts in a PromptQL project."
 keywords:
   - hasura
   - promptql

--- a/docs/project-configuration/promptql-config/index.mdx
+++ b/docs/project-configuration/promptql-config/index.mdx
@@ -16,8 +16,7 @@ toc_max_heading_level: 4
 ## Overview
 
 You can manage PromptQL's LLM settings and system instructions from a single `promptql_config.yaml` file, automatically
-created at the root of your DDN project when you initialize a project with the `--with-promptql` flag using the Hasura
-DDN CLI.
+created at the root of your project when you initialize a project with the `--with-promptql` flag using the CLI.
 
 ## Examples
 

--- a/docs/project-configuration/subgraphs/subgraph-prefixing.mdx
+++ b/docs/project-configuration/subgraphs/subgraph-prefixing.mdx
@@ -2,8 +2,7 @@
 sidebar_position: 5
 sidebar_label: Subgraph Prefixing
 description:
-  "Learn how to avoid naming collisions between subgraphs in Hasura DDN by customizing prefixes for root fields and type
-  names."
+  "Learn how to avoid naming collisions between subgraphs by customizing prefixes for root fields and type names."
 keywords:
   - subgraph prefixing
   - naming collisions
@@ -21,6 +20,8 @@ seoFrontMatterUpdated: true
 ---
 
 # Subgraph Prefixing
+
+## Introduction
 
 Subgraphs are namespaced and metadata object names are independent from one another and cannot conflict. However, the
 supergraph is where the subgraphs meet, potentially leading to naming collisions.

--- a/docs/project-configuration/subgraphs/working-with-multiple-repositories.mdx
+++ b/docs/project-configuration/subgraphs/working-with-multiple-repositories.mdx
@@ -34,7 +34,7 @@ domain (e.g., users, orders, products) and can be managed by different teams.
 :::tip Key Concepts
 
 - Supergraph and subgraph builds are immutable and have unique IDs
-- A subgraph must exist in the DDN project before inviting collaborators to it
+- A subgraph must exist in the PromptQL project before inviting collaborators to it
 - Each subgraph is namespaced and internal metadata objects cannot conflict with other subgraphs
 - The supergraph is where subgraphs meet and conflicts can occur with root field and type names
 - [Subgraph prefixing](/project-configuration/subgraphs/subgraph-prefixing.mdx) can automatically remedy naming
@@ -94,7 +94,7 @@ This will serve as the parent project.
 ddn supergraph init <parent-project> && cd <parent-project> && git init
 ```
 
-This will scaffold the local configuration for your DDN project and initialize a Git repository.
+This will scaffold the local configuration for your PromptQL project and initialize a Git repository.
 
 ### Step 2. Initialize the cloud project
 
@@ -117,8 +117,8 @@ Push this repository to your preferred hosting service to share it with collabor
 
 ### Step 4. Provision subgraphs on the cloud parent project
 
-If you know the subgraphs to include, you can provision them using the DDN CLI. Replace `<subgraph-name>` with the
-desired name:
+If you know the subgraphs to include, you can provision them using the CLI. Replace `<subgraph-name>` with the desired
+name:
 
 ```ddn
 ddn project subgraph create <subgraph-name>

--- a/docs/project-configuration/subgraphs/working-with-multiple-subgraphs.mdx
+++ b/docs/project-configuration/subgraphs/working-with-multiple-subgraphs.mdx
@@ -41,7 +41,7 @@ For more information about prefixing, see the
 ## Set subgraph context
 
 If you're working in a project with multiple subgraphs, there will be the need to switch between subgraphs when
-executing commands with the DDN CLI. While the CLI supports a `--subgraph` flag, it is much more convenient to set your
+executing commands with the CLI. While the CLI supports a `--subgraph` flag, it is much more convenient to set your
 subgraph in context.
 
 ```ddn title="Switch between context using the path to the subgraph's configuration file:"
@@ -103,8 +103,8 @@ In these cases the Hasura VS Code extension cannot validate the entirety of the 
 manually author cross-repo relationships and ensure that the field mappings are correct. However, upon creating a
 supergraph build, all cross-subgraph metadata is validated to prevent mistakes from being deployed to the final API.
 
-You can still easily use the Hasura DDN console to explore the supergraph and test relationships across subgraphs once
-you have created a build.
+You can still easily use the console to explore the supergraph and test relationships across subgraphs once you have
+created a build.
 
 If you perform a _local_ supergraph build using the CLI (ie. `ddn supergraph build local`), cross-repo relationships
 will be ignored and will not be validated. If you run the build locally you will only see the subgraphs in that
@@ -153,7 +153,7 @@ the relationship in action, you'll need to follow these steps:
 
 1. Create a new supergraph build on DDN using the `ddn supergraph build create` command. (Subgraph builds do not get an
    API, so supergraph builds are required to test.)
-2. You can then use the Hasura DDN console to explore and test the relationship across subgraphs.
+2. You can then use the console to explore and test the relationship across subgraphs.
 3. If you have admin permissions, you can apply the subgraph to the supergraph with the `ddn subgraph apply` command.
 
 Remember, cross-repo relationships only come into effect when the subgraphs are combined in the DDN environment. Local

--- a/docs/project-configuration/supergraph.mdx
+++ b/docs/project-configuration/supergraph.mdx
@@ -13,9 +13,9 @@ keywords:
 
 ## Introduction
 
-A supergraph is the foundation that enables PromptQL to accurately talk to all your data. It provides a unified
-structure for your data sources, allowing PromptQL to generate insightful queries and visualizations through a natural
-language conversation.
+A supergraph is the foundation that enables PromptQL to accurately talk to all your data. It provides a unified semantic
+metadata layer for your data sources, allowing PromptQL to generate insightful queries and visualizations through a
+natural language conversation.
 
 ## Components
 

--- a/docs/project-configuration/tutorials/independent-connector-deployment.mdx
+++ b/docs/project-configuration/tutorials/independent-connector-deployment.mdx
@@ -21,7 +21,7 @@ seoFrontMatterUpdated: false
 By default, the CLI command to build the supergraph, i.e.
 [ddn supergraph build create](/reference/cli/commands/ddn_supergraph_build_create.mdx), also builds the connectors
 required by the supergraph for convenience. Though in certain cases, you might want to do these steps independently,
-e.g. when the connectors are self-hosted and not deployed on Hasura DDN.
+e.g., when the connectors are self-hosted and not deployed on Hasura DDN.
 
 In this recipe, you'll learn how to manage independent deployments for your connectors and the supergraph.
 
@@ -29,7 +29,7 @@ In this recipe, you'll learn how to manage independent deployments for your conn
 
 Before continuing, ensure you have:
 
-- A [local Hasura project](/quickstart.mdx).
+- A [local PromptQL project](/quickstart.mdx).
 
 :::
 
@@ -124,7 +124,7 @@ The `--project`, `--supergraph` and `--env-file` flags can be skipped if the key
 
 ### Step 4. (Optional) Add a custom script to build the supergraph
 
-You can add the above command as a [custom script](/project/configuration/overview.mdxthe `--no-build-connectors` flag
+You can add the above command as a [custom script](/project-configuration/overview.mdx) the `--no-build-connectors` flag
 each time.
 
 For example, you can update your context config to the following:
@@ -167,4 +167,4 @@ The `--project`, `--supergraph` and `--env-file` flags can be skipped if the key
 
 ## Learn more
 
-- [Project configuration](/project/configuration/overview.mdx
+- [Project configuration](/project-configuration/overview.mdx)

--- a/docs/project-configuration/tutorials/manage-multiple-environments.mdx
+++ b/docs/project-configuration/tutorials/manage-multiple-environments.mdx
@@ -14,10 +14,10 @@ keywords:
 
 ## Introduction
 
-Managing multiple contexts in Hasura allows you to replicate the functionality of traditional environments like
-`staging` and `production`, but with greater flexibility. Instead of rigidly-defined environments, your application uses
-contexts to store key details such as project configurations, metadata, and environment variables. This approach lets
-you switch between different setups without disrupting your workflow or end users.
+Managing multiple contexts in your application allows you to replicate the functionality of traditional environments
+like `staging` and `production`, but with greater flexibility. Instead of rigidly-defined environments, your application
+uses contexts to store key details such as project configurations, metadata, and environment variables. This approach
+lets you switch between different setups without disrupting your workflow or end users.
 
 In this tutorial, you'll learn how to:
 
@@ -42,14 +42,16 @@ This will scaffold out the necessary files for a project in a new `environments-
 In this tutorial, we'll use the PostgreSQL connector and a sample PostgreSQL database:
 
 ```plaintext
-postgresql://read_only_user:readonlyuser@35.236.11.122:5432/v3-docs-sample-app
+jdbc:postgresql://35.236.11.122:5432/v3-docs-sample-app?user=read_only_user&password=readonlyuser
 ```
 
-```ddn title="In your project directory, run the following, choose hasura/postrges, and pass the connection URI above when prompted:"
+```ddn title="In your project directory, run the following, choose hasura/postrges-promptql, and pass the connection URI above when prompted:"
 ddn connector init my_pg -i
 ```
 
-### Step 3. Generate the Hasura metadata
+Be sure to include the `public` schema.
+
+### Step 3. Generate the metadata
 
 ```ddn title="Next, use the CLI to introspect the PostgreSQL database:"
 ddn connector introspect my_pg
@@ -58,11 +60,11 @@ ddn connector introspect my_pg
 After running this, you should see a representation of your database's schema in the
 `app/connector/my_pg/configuration.json` file; you can view this using `cat` or open the file in your editor.
 
-```ddn title="Now, track the table from your PostgreSQL database as a model in your DDN metadata:"
+```ddn title="Now, track the table from your PostgreSQL database as a model in your metadata:"
 ddn models add my_pg users
 ```
 
-Open the `app/metadata` directory and you'll find a newly-generated file: `Users.hml`. The DDN CLI will use this Hasura
+Open the `app/metadata` directory and you'll find a newly-generated file: `Users.hml`. The CLI will use this Hasura
 Metadata Language file to represent the `users` table from PostgreSQL in your API as a
 [model](/reference/metadata-reference/models.mdx).
 
@@ -74,7 +76,7 @@ ddn supergraph build local
 
 The build is stored as a set of JSON files in `engine/build`.
 
-```ddn title="Start your local Hasura instance and PostgreSQL connector:"
+```ddn title="Start your local query engine and PostgreSQL connector:"
 ddn run docker-start
 ```
 

--- a/docs/project-configuration/tutorials/remove-subgraph.mdx
+++ b/docs/project-configuration/tutorials/remove-subgraph.mdx
@@ -23,7 +23,7 @@ In this recipe, you'll learn how to remove a subgraph from your local project di
 
 Before continuing, ensure you have:
 
-- A [local Hasura project](/quickstart.mdx).
+- A [local PromptQL project](/quickstart.mdx).
 - Stopped any running docker services related to the project.
 
 :::

--- a/docs/project-configuration/tutorials/rename-subgraph.mdx
+++ b/docs/project-configuration/tutorials/rename-subgraph.mdx
@@ -23,7 +23,7 @@ In this recipe, you'll learn how to rename a subgraph in your local project dire
 
 Before continuing, ensure you have:
 
-- A [local Hasura DDN project](/quickstart.mdx).
+- A [local PromptQL project](/quickstart.mdx).
 - Stopped any running docker services related to the project.
 
 :::
@@ -32,8 +32,8 @@ Before continuing, ensure you have:
 
 ### Step 1. Update subgraph config files
 
-Update the name of the subgraph in all the [subgraph config files](/project/configuration/overview.mdxthe subgraph. The
-subgraph config is typically located at `<subgraph-name>/subgraph.yaml`.
+Update the name of the subgraph in all the [subgraph config files](/project-configuration/overview.mdx) the subgraph.
+The subgraph config is typically located at `<subgraph-name>/subgraph.yaml`.
 
 ```yaml title="<subgraph-name>/subgraph.yaml"
 kind: Subgraph
@@ -51,7 +51,7 @@ definition:
 
 ### Step 2. Update connector config files of the subgraph
 
-Update the reference of the subgraph in all the [connector config files](/project/configuration/overview.mdxsubgraph.
+Update the reference of the subgraph in all the [connector config files](/project-configuration/overview.mdx) subgraph.
 The connector config is typically located at `<subgraph-name>/connector/<connector-name>/connector.yaml`.
 
 ```yaml title="<subgraph-name>/connector/<connector-name>/connector.yaml"
@@ -69,7 +69,7 @@ definition:
 
 ### Step 3. Update compose files of connectors of the subgraph
 
-Update the name of the connector service in the [compose file](/project/configuration/overview.mdxthe connectors
+Update the name of the connector service in the [compose file](/project-configuration/overview.mdx) the connectors
 belonging to the subgraph. The connector compose file is typically located at
 `<project-root>/<subgraph-name>/connector/<connector-name>/compose.yaml`.
 
@@ -96,8 +96,8 @@ typically be in:
 
 #### Step 4.1. Supergraph config files
 
-Update the path to the subgraph config files in all [supergraph config files](/project/configuration/overview.mdxlocated
-at the project root, i.e., `<project-root>/supergraph.yaml`.
+Update the path to the subgraph config files in all [supergraph config files](/project-configuration/overview.mdx)
+located at the project root, i.e., `<project-root>/supergraph.yaml`.
 
 ```yaml title="supergraph.yaml"
 kind: Supergraph
@@ -113,8 +113,8 @@ definition:
 
 #### Step 4.2. Engine compose file
 
-Update the path to the connector compose files included in the engine [compose
-file](/project/configuration/overview.mdxproject root, i.e., `<project-root>/compose.yaml`.
+Update the path to the connector compose files included in the engine
+[compose file](/project-configuration/overview.mdx) project root, i.e., `<project-root>/compose.yaml`.
 
 ```yaml title="compose.yaml"
 include:
@@ -131,8 +131,8 @@ services:
 
 #### Step 4.3. Context config
 
-The [context config file](/project/configuration/overview.mdxsubgraph config file path saved in the context. Update the
-subgraph config path if set.
+The [context config file](/project-configuration/overview.mdx) subgraph config file path saved in the context. Update
+the subgraph config path if set.
 
 ```yaml title=".hasura/context.yaml"
 kind: Context
@@ -150,4 +150,4 @@ definition:
 
 ## Learn more
 
-- [Project configuration](/project/configuration/overview.mdx
+- [Project configuration](/project-configuration/overview.mdx)

--- a/docs/project-configuration/tutorials/work-with-multiple-repositories.mdx
+++ b/docs/project-configuration/tutorials/work-with-multiple-repositories.mdx
@@ -53,7 +53,7 @@ provisioning subgraphs, inviting collaborators, and managing the API as a whole.
 ddn supergraph init parent-project --with-promptql && cd parent-project && git init
 ```
 
-This will scaffold out the local configuration for a DDN project and initialize a git repository.
+This will scaffold out the local configuration for a PromptQL project and initialize a git repository.
 
 ### Step 2. Create a commit
 
@@ -143,12 +143,14 @@ These will prevent collisions of root fields and types when your supergraph is b
 In this tutorial, we'll use the PostgreSQL connector and a sample PostgreSQL database:
 
 ```plaintext
-postgresql://read_only_user:readonlyuser@35.236.11.122:5432/v3-docs-sample-app
+jdbc:postgresql://35.236.11.122:5432/v3-docs-sample-app?user=read_only_user&password=readonlyuser
 ```
 
-```ddn title="In your project directory, run the following, choose hasura/postrges, and pass the connection URI above when prompted:"
+```ddn title="In your project directory, run the following, choose hasura/postrges-promptql, and pass the connection URI above when prompted:"
 ddn connector init customers_pg -i
 ```
+
+Be sure to include the `public` schema.
 
 ##### Generate the Hasura metadata
 
@@ -160,11 +162,11 @@ After running this, you should see a representation of your database's schema in
 `customers/connector/customers_pg/configuration.json` file; you can view this using `cat` or open the file in your
 editor.
 
-```ddn title="Now, track the table from your PostgreSQL database as a model in your DDN metadata:"
+```ddn title="Now, track the table from your PostgreSQL database as a model in your metadata:"
 ddn models add customers_pg users
 ```
 
-Open the `customers/metadata` directory and you'll find a newly-generated file: `Users.hml`. The DDN CLI will use this
+Open the `customers/metadata` directory and you'll find a newly-generated file: `Users.hml`. The CLI will use this
 Hasura Metadata Language file to represent the `users` table from PostgreSQL in your application as a
 [model](/reference/metadata-reference/models.mdx).
 
@@ -300,8 +302,8 @@ After running this, you should see a representation of your database's schema in
 ddn models add billing_pg orders
 ```
 
-Open the `billing/metadata` directory and you'll find a newly-generated file: `Orders.hml`. The DDN CLI will use this
-Hasura Metadata Language file to represent the `orders` table from PostgreSQL in your application as a
+Open the `billing/metadata` directory and you'll find a newly-generated file: `Orders.hml`. The CLI will use this Hasura
+Metadata Language file to represent the `orders` table from PostgreSQL in your application as a
 [model](/reference/metadata-reference/models.mdx).
 
 ##### Create a new local build and test the API
@@ -312,7 +314,7 @@ ddn supergraph build local
 
 The build is stored as a set of JSON files in `engine/build`.
 
-```ddn title="Start your local Hasura Engine and PostgreSQL connector:"
+```ddn title="Start your local query engine and PostgreSQL connector:"
 ddn run docker-start
 ```
 
@@ -355,15 +357,18 @@ before applying the build to the supergraph. In order to apply the build, you mu
 ddn supergraph build apply <supergraph-build-version>
 ```
 
-:::tip Streamline team collaboration For more efficient development across multiple repositories, you can create and
-apply the supergraph build in a single command using
+:::tip Streamline team collaboration
+
+For more efficient development across multiple repositories, you can create and apply the supergraph build in a single
+command using
 `ddn supergraph build create --subgraph-version billing:<build-version> --base-supergraph-version <supergraph-build-id> --apply`
+
 :::
 
 :::warning Make sure to stop all running services
 
 As a multi-repository setup is intended to be utilized by multiple persons across teams, you're not likely to have
-multiple instances of your Hasura DDN Engine and other services running at the same time on your machine. Ensure you've
+multiple instances of your query engine and other services running at the same time on your machine. Ensure you've
 killed all active services before proceeding to the next step.
 
 :::
@@ -417,6 +422,6 @@ Provide me with a listing of all customers and their orders.
 ## Recap
 
 By organizing your project into multiple repositories, you can create a flexible and collaborative workflow for subgraph
-development in Hasura. Starting with a parent project, you learned how to provision subgraphs, invite collaborators, and
-manage builds to integrate subgraph changes into a unified supergraph. This structure ensures teams can work
-independently while maintaining seamless integration and coordination across the entire application.
+development. Starting with a parent project, you learned how to provision subgraphs, invite collaborators, and manage
+builds to integrate subgraph changes into a unified supergraph. This structure ensures teams can work independently
+while maintaining seamless integration and coordination across the entire application.

--- a/docs/project-configuration/tutorials/work-with-multiple-subgraphs.mdx
+++ b/docs/project-configuration/tutorials/work-with-multiple-subgraphs.mdx
@@ -43,12 +43,14 @@ ddn supergraph init subgraph-example --with-promptql && cd subgraph-example
 In this tutorial, we'll use the PostgreSQL connector and a sample PostgreSQL database:
 
 ```plaintext
-postgresql://read_only_user:readonlyuser@35.236.11.122:5432/v3-docs-sample-app
+jdbc:postgresql://35.236.11.122:5432/v3-docs-sample-app?user=read_only_user&password=readonlyuser
 ```
 
-```ddn title="In your project directory, run the following, choose hasura/postrges, and pass the connection URI above when prompted:"
+```ddn title="In your project directory, run the following, choose hasura/postrges-promptql, and pass the connection URI above when prompted:"
 ddn connector init customers_pg -i
 ```
+
+Be sure to include the `public` schema.
 
 ### Step 3. Generate the Hasura metadata
 
@@ -59,11 +61,11 @@ ddn connector introspect customers_pg
 After running this, you should see a representation of your database's schema in the
 `app/connector/customers_pg/configuration.json` file; you can view this using `cat` or open the file in your editor.
 
-```ddn title="Now, track the table from your PostgreSQL database as a model in your DDN metadata:"
+```ddn title="Now, track the table from your PostgreSQL database as a model in your metadata:"
 ddn models add customers_pg users
 ```
 
-Open the `app/metadata` directory and you'll find a newly-generated file: `Users.hml`. The DDN CLI will use this Hasura
+Open the `app/metadata` directory and you'll find a newly-generated file: `Users.hml`. The CLI will use this Hasura
 Metadata Language file to represent the `users` table from PostgreSQL in your application as a
 [model](/reference/metadata-reference/models.mdx).
 
@@ -75,7 +77,7 @@ ddn supergraph build local
 
 The build is stored as a set of JSON files in `engine/build`.
 
-```ddn title="Start your local Hasura instance and PostgreSQL connector:"
+```ddn title="Start your local query engine and PostgreSQL connector:"
 ddn run docker-start
 ```
 
@@ -95,7 +97,7 @@ Show me all the users in my application.
 
 ### Step 5. Create a new `billing` subgraph
 
-```ddn title="Use the DDN CLI to create the subgraph in your local metadata:"
+```ddn title="Use the CLI to create the subgraph in your local metadata:"
 ddn subgraph init billing --graphql-type-name-prefix billing
 ```
 
@@ -142,12 +144,14 @@ required — we're referencing the `billing` subgraph.
 As before, we'll use the PostgreSQL connector with the same sample database:
 
 ```plaintext
-postgresql://read_only_user:readonlyuser@35.236.11.122:5432/v3-docs-sample-app
+jdbc:postgresql://35.236.11.122:5432/v3-docs-sample-app?user=read_only_user&password=readonlyuser
 ```
 
 ```ddn title="In your project directory, run:"
 ddn connector init billing_pg -i
 ```
+
+Be sure to include the `public` schema.
 
 :::info Notice where this connector was added
 
@@ -169,8 +173,8 @@ After running this, you should see a representation of the database's schema in 
 ddn models add billing_pg orders
 ```
 
-Open the `billing/metadata` directory and you'll find a newly-generated file: `PaymentInformation.hml`. The DDN CLI will
-use this Hasura Metadata Language file to represent the `payment_information` table from PostgreSQL in your API as a
+Open the `billing/metadata` directory and you'll find a newly-generated file: `PaymentInformation.hml`. The CLI will use
+this Hasura Metadata Language file to represent the `payment_information` table from PostgreSQL in your API as a
 [model](/reference/metadata-reference/models.mdx).
 
 ### Step 9. Create a new local build and test the application
@@ -183,7 +187,7 @@ ddn supergraph build local
 CTRL+C
 ```
 
-```ddn title="Restart your local Hasura DDN Engine and PostgreSQL connector:"
+```ddn title="Restart your local query engine and PostgreSQL connector:"
 ddn run docker-start
 ```
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -19,13 +19,14 @@ import Quickstart from "@site/docs/_quickstart_template.mdx";
 
 # Quickstart with PromptQL
 
-In this getting started guide, you'll get hands-on with PromptQL by deploying it and connecting to a sample dataset.
-You'll use a hosted PostgreSQL database pre-loaded with IMDb movie data. You’ll be able to chat with the data to explore
-information about different movies. Then, you'll add custom business logic that lets PromptQL take action — like renting
-a movie on a user's behalf.
+In this getting started guide, you'll deploy PromptQL and connect it to a sample dataset — a hosted PostgreSQL database
+pre-loaded with IMDb movie data. You'll start by exploring the dataset through natural language queries, discovering how
+PromptQL can reliably answer questions and assist in decision-making. Then, you'll add custom business logic that lets
+PromptQL act on your behalf — like renting a movie for a user — showing how it can go beyond answering questions to
+automating tasks.
 
 <Prereqs />
 
-## Build your First PromptQL app
+## Build your first PromptQL app
 
 <Quickstart />

--- a/src/components/DemoGallery/index.tsx
+++ b/src/components/DemoGallery/index.tsx
@@ -67,8 +67,8 @@ export default function DemoGallery() {
   return (
     <>
       <p>
-        Check out these demos to get a feel for how PromptQL works. Each of these will take you to a README outlining
-        the connected data sources and will suggest some ways of interacting with the application.
+        Each demo below will take you to a README outlining the connected data sources and
+        give you a feel for how PromptQL works by suggesting some questions to ask.
       </p>
       <div className={`homepage-demo-container ${isExpanded ? 'expanded' : ''}`}>
         <div className="homepage-demo-grid">


### PR DESCRIPTION
## Description 📝

This PR has two primary goals:
- Incorporate the messaging from the OTD deck so the way we refer to concepts is aligned with the way we're talking about PromtpQL elsewhere
- Clean up DDN references using the guidance found ☝️ 

For the latter, this typically takes the following shape:

| Old term | New term |
| --- | --- |
| supergraph | agentic\|semantic metadata layer |
| ddn [engine] | distributed query engine |
| DDN CLI | CLI |
| Hasura metadata | metadata |

> [!TIP]
> For the reviewer:
> The PR is broken into commits by each section of docs; I'd recommend reviewing in the same fashion as it can be a lot.
>
> Additionally, I'd also recommend examining the following pages in isolation: `docs/index.mdx` &`docs/quickstart.mdx`.

### Considerations
- The term `supergraph` is still very much necessary and accurate, but is used more specifically now
- I avoided touching the following sections: Deployment, Private DDN, pre-built metadata & CLI reference docs, and Policies.