### PR TITLE
Update promptql metadata version from v1 to v2

### DIFF
--- a/docs/project-configuration/promptql-config/providers.mdx
+++ b/docs/project-configuration/promptql-config/providers.mdx
@@ -26,7 +26,7 @@ For example, you can use one model for conversational tasks and another for adva
 
 ```yaml {5-6,8-9}
 kind: PromptQlConfig
-version: v1
+version: v2
 definition:
   llm:
     provider: openai
@@ -86,8 +86,8 @@ With Hasura—used as the default provider—there is **no specific model necess
 
 :::warning HIPAA Compliance
 
-If you plan to interact with PHI using PromptQL, you should not use the Hasura provider as it is not 
-HIPAA compliant. You will have to bring your own LLM with another supported provider.
+If you plan to interact with PHI using PromptQL, you should not use the Hasura provider as it is not HIPAA compliant.
+You will have to bring your own LLM with another supported provider.
 
 :::
 

--- a/docs/project-configuration/promptql-config/providers.mdx
+++ b/docs/project-configuration/promptql-config/providers.mdx
@@ -24,14 +24,16 @@ and the freedom to switch between providers and models as needed depending the t
 
 For example, you can use one model for conversational tasks and another for advanced AI primitives:
 
-```yaml {5-6,8-9}
+```yaml {5-6,8-9} title="Example of globals/metadata/promptql-config.hml"
 kind: PromptQlConfig
 version: v2
 definition:
   llm:
     provider: openai
     model: o3-mini
-  ai_primitives_llm:
+    apiKey:
+      valueFromEnv: OPENAI_API_KEY
+  aiPrimitivesLlm:
     provider: openai
     model: gpt-4o
 ```
@@ -41,9 +43,9 @@ definition:
 The `llm` configuration is used to define the LLM provider and model for **conversational tasks** in your application.
 In the example above, we're using `openai` as the provider with the `o3-mini` model.
 
-### `ai_primitives_llm`
+### `aiPrimitivesLlm`
 
-The `ai_primitives_llm` configuration is used to define the LLM provider and model for
+The `aiPrimitivesLlm` configuration is used to define the LLM provider and model for
 [**AI primitives** in your application](/promptql-apis/execute-program-api.mdx). This is used for tasks such as
 **program generation and execution**. In the example above, we're using `openai` as the provider with the `gpt-4o`
 model.
@@ -140,6 +142,7 @@ definition:
 ```
 
 Be sure to also include the key-value pair for your API key (`<PROVIDER>_API_KEY=your-key`) in your project's `.env`
-files.
+files and if you're developing locally, in the root `compose.yaml` file in `services.promptql-playground.environment` as
+well.
 
 :::

--- a/docs/project-configuration/promptql-config/system-instructions.mdx
+++ b/docs/project-configuration/promptql-config/system-instructions.mdx
@@ -21,13 +21,13 @@ interprets questions and crafts responses.
 
 **While powerful, use this feature judiciously to maintain optimal performance.**
 
-```yaml title="Consider this example where we set the system instructions using the PromptQlConfig file:"
+```yaml title="Consider this example where we set the system instructions using the promptql-config.hml file:"
 kind: PromptQlConfig
 version: v2
 definition:
   llm:
     provider: hasura
-  system_instructions: |
+  systemInstructions: |
 
     You are an AI assistant that helps go-to-market teams make data-driven decisions.
 

--- a/docs/project-configuration/promptql-config/system-instructions.mdx
+++ b/docs/project-configuration/promptql-config/system-instructions.mdx
@@ -23,7 +23,7 @@ interprets questions and crafts responses.
 
 ```yaml title="Consider this example where we set the system instructions using the PromptQlConfig file:"
 kind: PromptQlConfig
-version: v1
+version: v2
 definition:
   llm:
     provider: hasura

--- a/docs/reference/metadata-reference/promptql-config.mdx
+++ b/docs/reference/metadata-reference/promptql-config.mdx
@@ -28,10 +28,12 @@ definition:
   llm:
     provider: openai
     model: o3-mini
-  ai_primitives_llm:
+    apiKey:
+      valueFromEnv: OPENAI_API_KEY
+  aiPrimitivesLlm:
     provider: openai
     model: gpt-4o
-  system_instructions: |
+  systemInstructions: |
     You are a helpful AI Assistant.
 ```
 

--- a/docs/reference/metadata-reference/promptql-config.mdx
+++ b/docs/reference/metadata-reference/promptql-config.mdx
@@ -21,7 +21,7 @@ toc_max_heading_level: 4
 Your PromptQlConfig is a metadata object that defines the configuration of PromptQL for your project. It includes the
 LLM to be used, the system instructions, and other settings.
 
-```yaml title="Example PromptQlConfig"
+```yaml title="Example of globals/metadata/promptql-config.hml"
 kind: PromptQlConfig
 version: v2
 definition:


### PR DESCRIPTION
## Description 📝

- Update PromptQlConfig version to v2 in How To docs
- Update system instructions version in PromptQlConfig from v1 to v2 in How to Docs
- Update promptql-config in Reference

## Quick Links 🚀

[/project-configuration/promptql-config/providers](https://sean-fix-promptql-version.promptql-docs.pages.dev/project-configuration/promptql-config/providers/)
[/project-configuration/promptql-config/system-instructions](https://sean-fix-promptql-version.promptql-docs.pages.dev/project-configuration/promptql-config/system-instructions/)
[/reference/metadata-reference/promptql-config](https://sean-fix-promptql-version.promptql-docs.pages.dev/reference/metadata-reference/promptql-config/)

