### PR TITLE
Docs: Add typecasting guide

### DIFF
--- a/docs/data-modeling/typecasting.mdx
+++ b/docs/data-modeling/typecasting.mdx
@@ -1,0 +1,84 @@
+---
+sidebar_position: 6
+sidebar_label: Recast types
+description: "Learn how to cast types at your metadata layer."
+keywords:
+  - data modeling
+  - promptql
+  - ai
+  - typecast
+  - recast
+title: Typecasting
+---
+
+# Recast Types
+
+## Overview
+
+At times, your database schema may not perfectly align with how you want to expose data types in your API. For example,
+you might have text fields that contain numeric values, JSON fields you want to filter as strings, or custom database
+types that would work better as standard types in your API.
+
+Your semantic metadata layer allows you to recast these types without requiring any changes to your underlying
+datasource schema. This powerful feature enables you to unlock type-specific operations like numeric aggregations on
+text fields or string filtering on JSON data, all through simple metadata configuration changes.
+
+## Step 1. Update the representation mapping
+
+In the `<connector-name>-types.hml` file for your connector, you'll find definitions and mappings for your data source's
+types. For the type you wish to recast, you'll need to identify the correct `DataConnectorScalarRepresentation` and
+change the value for the `representation` key.
+
+If you don't know which types are available when recasting, trigger the
+[Hasura VS Code extension](https://marketplace.visualstudio.com/items?itemName=HasuraHQ.hasura) by pressing
+`CTRL+SPACEBAR`. Check out the example below.
+
+```yaml title="Here we'll change a text type (represented as a string):" {6}
+kind: DataConnectorScalarRepresentation
+version: v1
+definition:
+  dataConnectorName: pg
+  dataConnectorScalarType: text
+  representation: string
+  graphql:
+    comparisonExpressionTypeName: string_comparison_exp
+```
+
+```yaml title="To an int:" {6,8}
+kind: DataConnectorScalarRepresentation
+version: v1
+definition:
+  dataConnectorName: pg
+  dataConnectorScalarType: text
+  representation: int32
+  graphql:
+    comparisonExpressionTypeName: text_as_int32_comparison_exp
+```
+
+:::tip Comparison Expression Type
+
+We're also amending the `comparisonExpressionTypeName` as these must be unique.
+
+:::
+
+## Step 2. Regenerate your metadata
+
+```ddn title="Update your metadata by running the following:"
+ddn model add <connector-name> "*"
+```
+
+This will update your metadata to use the new type; you'll find changes in both the `<connector-name>-types.hml` file
+for various expressions (such as aggregates and boolean) and any models which use the recast type.
+
+## Step 3. Test it out
+
+```ddn title="Rebuild your metadata:"
+ddn supergraph build local
+```
+
+```ddn title="Then, restart your services:"
+ddn run docker-start
+```
+
+If you explore your metadata, you'll see the type recast, allowing you to perform operations that weren't previously
+possible.


### PR DESCRIPTION
## Description 📝

Adds a guide for recasting types using a string » int example.

This has been validated using a sample Postgres schema that has the following shape:

```sql
CREATE TABLE "public"."order_items" (
    "id" integer DEFAULT nextval('order_items_id_seq') NOT NULL,
    "order_id" integer NOT NULL,
    "product_name" character varying(255) NOT NULL,
    "quantity_text" text NOT NULL,
    "price_text" text NOT NULL,
    "category_code" text NOT NULL,
    CONSTRAINT "order_items_pkey" PRIMARY KEY ("id")
)

INSERT INTO "order_items" ("id", "order_id", "product_name", "quantity_text", "price_text", "category_code") VALUES
(1,	1001,	'Laptop',	'2',	'999.99',	'1'),
(2,	1001,	'Mouse',	'1',	'25.50',	'2'),
(3,	1002,	'Monitor',	'1',	'299.99',	'1'),
(4,	1002,	'Keyboard',	'3',	'75.00',	'2'),
(5,	1003,	'Tablet',	'1',	'499.99',	'1'),
(6,	1003,	'Headphones',	'2',	'149.99',	'3'),
(7,	1004,	'Phone',	'1',	'799.99',	'1'),
(8,	1004,	'Charger',	'4',	'19.99',	'2'),
(9,	1005,	'Speakers',	'2',	'89.99',	'3'),
(10,	1005,	'Cable',	'5',	'9.99',	'2');
```

Which was then recast at the metadata level using the steps in the guide.

## Quick Links 🚀

[Recasting guide](https://robdominguez-doc-2918-create.promptql-docs.pages.dev/data-modeling/typecasting/)