### PR TITLE
docs for `AuthConfig` v4 (multiple auth mode support)

### DIFF
--- a/docs/auth/jwt/jwt-configuration.mdx
+++ b/docs/auth/jwt/jwt-configuration.mdx
@@ -23,7 +23,7 @@ Example JSON Web Token (JWT) payload configuration definition:
 
 ```yaml title="globals/metadata/auth-config.hml"
 kind: AuthConfig
-version: v3
+version: v4
 definition:
   mode:
     jwt:
@@ -429,7 +429,7 @@ Examples:
 
 ```yaml
 kind: AuthConfig
-version: v3
+version: v4
 definition:
   mode:
     jwt:
@@ -462,7 +462,7 @@ Examples:
 
 ```yaml
 kind: AuthConfig
-version: v3
+version: v4
 definition:
   mode:
     jwt:
@@ -491,7 +491,7 @@ will look like:
 
 ```yaml
 kind: AuthConfig
-version: v3
+version: v4
 definition:
   mode:
     jwt:
@@ -519,7 +519,7 @@ have the public key.
 
 ```yaml
 kind: AuthConfig
-version: v3
+version: v4
 definition:
   mode:
     jwt:
@@ -543,7 +543,7 @@ definition:
 
 ```yaml
 kind: AuthConfig
-version: v3
+version: v4
 definition:
   mode:
     jwt:
@@ -567,7 +567,7 @@ definition:
 
 ```yaml
 kind: AuthConfig
-version: v3
+version: v4
 definition:
   mode:
     jwt:
@@ -590,7 +590,7 @@ the public key.
 
 ```yaml
 kind: AuthConfig
-version: v3
+version: v4
 definition:
   mode:
     jwt:
@@ -613,7 +613,7 @@ definition:
 
 ```yaml
 kind: AuthConfig
-version: v3
+version: v4
 definition:
   mode:
     jwt:
@@ -642,7 +642,7 @@ needs to have the public key.
 
 ```yaml
 kind: AuthConfig
-version: v3
+version: v4
 definition:
   mode:
     jwt:
@@ -666,7 +666,7 @@ definition:
 
 ```yaml
 kind: AuthConfig
-version: v3
+version: v4
 definition:
   mode:
     jwt:
@@ -690,7 +690,7 @@ definition:
 
 ```yaml
 kind: AuthConfig
-version: v3
+version: v4
 definition:
   mode:
     jwt:
@@ -750,7 +750,7 @@ If you are using Firebase, use this config:
 
 ```yaml
 kind: AuthConfig
-version: v3
+version: v4
 definition:
   mode:
     jwt:

--- a/docs/auth/jwt/jwt-mode.mdx
+++ b/docs/auth/jwt/jwt-mode.mdx
@@ -73,7 +73,7 @@ variable. However, we support other methods for
 
 ```yaml title="globals/metadata/auth-config.hml"
 kind: AuthConfig
-version: v3
+version: v4
 definition:
   mode:
     jwt:

--- a/docs/auth/jwt/tutorials/integrations/1-auth0.mdx
+++ b/docs/auth/jwt/tutorials/integrations/1-auth0.mdx
@@ -95,7 +95,7 @@ Update your AuthConfig object to use JWT mode and your
 
 ```yaml
 kind: AuthConfig
-version: v3
+version: v4
 definition:
   mode:
     jwt:

--- a/docs/auth/jwt/tutorials/integrations/2-aws-cognito.mdx
+++ b/docs/auth/jwt/tutorials/integrations/2-aws-cognito.mdx
@@ -97,7 +97,7 @@ which you can find on your User pool overview card:
 
 ```yaml
 kind: AuthConfig
-version: v3
+version: v4
 definition:
   mode:
     jwt:

--- a/docs/auth/jwt/tutorials/integrations/3-firebase.mdx
+++ b/docs/auth/jwt/tutorials/integrations/3-firebase.mdx
@@ -96,7 +96,7 @@ Update your AuthConfig object to use JWT mode and your
 
 ```yaml
 kind: AuthConfig
-version: v3
+version: v4
 definition:
   mode:
     jwt:

--- a/docs/auth/jwt/tutorials/integrations/4-clerk.mdx
+++ b/docs/auth/jwt/tutorials/integrations/4-clerk.mdx
@@ -74,7 +74,7 @@ sidenav under `Domains`:
 
 ```yaml
 kind: AuthConfig
-version: v3
+version: v4
 definition:
   mode:
     jwt:

--- a/docs/auth/jwt/tutorials/setup-test-jwt.mdx
+++ b/docs/auth/jwt/tutorials/setup-test-jwt.mdx
@@ -50,7 +50,7 @@ Set up an `AuthConfig` object in your project which uses this secret key.
 
 ```yaml title="In globals/metadata/auth-config.hml:"
 kind: AuthConfig
-version: v3
+version: v4
 definition:
   mode:
     jwt:

--- a/docs/auth/multiple-auth-modes.mdx
+++ b/docs/auth/multiple-auth-modes.mdx
@@ -91,7 +91,7 @@ definition:
           claimsConfig:
             namespace:
               claimsFormat: Json
-              location: "https://hasura.io/jwt/claims"
+              location: "/https:~1~1hasura.io~1jwt~1claims"
           tokenLocation: 
             type: Header
             name: "Authorization"

--- a/docs/auth/multiple-auth-modes.mdx
+++ b/docs/auth/multiple-auth-modes.mdx
@@ -1,0 +1,140 @@
+---
+sidebar_position: 6
+description: "Learn how to configure and use multiple authentication modes in Hasura DDN."
+keywords:
+  - hasura authentication
+  - multiple auth modes
+  - jwt authentication
+  - webhook authentication
+  - noauth mode
+  - auth switching
+  - X-Hasura-Auth-Mode
+sidebar_label: Multiple Auth Modes
+---
+
+import Thumbnail from "@site/src/components/Thumbnail";
+
+# Multiple Authentication Modes
+
+## Introduction
+
+Hasura DDN supports configuring multiple authentication modes simultaneously, allowing you to use different
+authentication methods for different scenarios or clients. This feature enables you to have both JWT and webhook
+authentication enabled, or multiple configurations of the same authentication type with different settings.
+
+:::info AuthConfig v4
+
+Multiple authentication modes are available in `AuthConfig` **v4** and above.
+
+:::
+
+## How It Works
+
+When multiple authentication modes are configured:
+
+1. The primary mode specified in the `mode` field of the `AuthConfig` is used by default
+2. Alternative modes can be accessed by passing the `X-Hasura-Auth-Mode` header with the identifier of the desired
+   authentication mode
+3. Each alternative mode has its own complete authentication configuration
+
+The default mode is used when:
+
+- The `X-Hasura-Auth-Mode` header is not provided
+- The provided `X-Hasura-Auth-Mode` header does not match any of the alternative mode identifiers
+
+## Configuring Multiple Auth Modes
+
+To configure multiple authentication modes, you need to use `AuthConfig` v4, which introduces the `alternativeModes`
+field.
+
+### Example Configuration
+
+Here's an example of an `AuthConfig` with multiple authentication modes:
+
+```yaml
+kind: AuthConfig
+version: v4
+definition:
+  mode:
+    jwt:
+      key:
+        fixed:
+          algorithm: HS256
+          key:
+            valueFromEnv: JWT_KEY
+      tokenLocation:
+        type: BearerAuthorization
+      claimsConfig:
+        namespace:
+          claimsFormat: Json
+          location: "/https:~1~1hasura.io~1jwt~1claims"
+  alternativeModes:
+    - identifier: "user2"
+      config:
+        webhook:
+          url:
+            valueFromEnv: USER2_URL
+          method: "POST"
+    - identifier: "webhook"
+      config:
+        webhook:
+          url:
+            value: "https://my-auth-service.example.com/validate"
+          method: "POST"
+    - identifier: "jwt"
+      config:
+        jwt:
+          key:
+            jwkFromUrl: "https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com"
+          audience: ["my-firebase-app"]
+          issuer: "https://securetoken.google.com/my-firebase-app"
+          claimsConfig:
+            namespace:
+              claimsFormat: Json
+              location: "https://hasura.io/jwt/claims"
+          tokenLocation: 
+            type: Header
+            name: "Authorization"
+```
+
+In this example:
+
+- The default authentication mode is `jwt` with a fixed key
+- Three alternative modes are configured:
+  - `user2`: A webhook authentication configuration for a different user
+  - `webhook`: A webhook authentication configuration
+  - `jwt`: A JWT authentication configuration for Firebase
+
+## Using Multiple Auth Modes
+
+To use a specific authentication mode when making a request to your Hasura DDN API, include the `X-Hasura-Auth-Mode`
+header with the identifier of the desired mode. You can pass this value in via the [PromptQL
+Playground](/auth/playground-auth.mdx).
+
+## Use Cases
+
+Multiple authentication modes can be useful in various scenarios:
+
+1. **Development and Testing**: Use fixed key JWT for development and webhook for testing, and switch to production
+   custom claims JWT mode when ready
+2. **Multiple Client Types**: Support different authentication methods for different client applications
+3. **Migration**: Gradually migrate from one authentication provider to another (or from one permission model to
+   another)
+4. **Admin Access**: Provide a separate authentication mode for administrative access
+
+## Security Considerations
+
+When using multiple authentication modes:
+
+- Set up role-based permissions for each authentication mode to control data access appropriately
+- Keep in mind that the `X-Hasura-Auth-Mode` header may be included in standard HTTP request monitoring tools, just like
+  other headers
+- Consider using network controls (like IP allowlists) or the
+  [Allowlist Plugin](https://hasura.io/docs/3.0/plugins/allowlist/) to manage which clients can use specific
+  authentication modes
+
+## Next Steps
+
+- Learn more about [JWT authentication](/auth/jwt/index.mdx)
+- Explore [webhook authentication](/auth/webhook/index.mdx)
+- Understand [NoAuth mode](/auth/noauth-mode.mdx)

--- a/docs/auth/noauth-mode.mdx
+++ b/docs/auth/noauth-mode.mdx
@@ -36,7 +36,7 @@ configured for noAuth mode.
 
 ```yaml title="An AuthConfig for noAuth mode:"
 kind: AuthConfig
-version: v3
+version: v4
 definition:
   mode:
     noAuth:

--- a/docs/auth/overview.mdx
+++ b/docs/auth/overview.mdx
@@ -40,8 +40,13 @@ Learn how to check the auth which the PromptQL Playground client is using [here]
 
 ## AuthConfig options
 
-Authentication can be set up in one of three modes. These modes and their configuration options are specified in the
-`AuthConfig` object within your metadata.
+Authentication can be set up in one of three modes or multiple modes. These modes and their configuration options are
+specified in the `AuthConfig` object within your metadata.
+
+You can configure a single authentication mode or multiple authentication modes using the `alternativeModes` field in
+`AuthConfig` v4. When using multiple authentication modes, you can specify which mode to use for a particular request by
+including the `X-Hasura-Auth-Mode` header with the identifier of the desired authentication mode. [Read more about
+multiple auth modes](/auth/multiple-auth-modes.mdx).
 
 ### JWT mode
 

--- a/docs/auth/webhook/webhook-mode.mdx
+++ b/docs/auth/webhook/webhook-mode.mdx
@@ -56,7 +56,7 @@ In the example below, we're demonstrating a sample authentication webhook.
 
 ```yaml title="globals/metadata/auth-config.hml"
 kind: AuthConfig
-version: v3
+version: v4
 definition:
   mode:
     webhook:

--- a/docs/project-configuration/project-management/manage-environments.mdx
+++ b/docs/project-configuration/project-management/manage-environments.mdx
@@ -46,7 +46,7 @@ definition:
 
 ```yaml title="globals/metadata_development/auth-config.hml"
 kind: AuthConfig
-version: v3
+version: v4
 definition:
   mode:
     noAuth:

--- a/docs/reference/metadata-reference/auth-config.mdx
+++ b/docs/reference/metadata-reference/auth-config.mdx
@@ -50,7 +50,7 @@ started. Check the reference table for more information on each field.
 
 ```yaml title="An AuthConfig for noAuth mode:"
 kind: AuthConfig
-version: v3
+version: v4
 definition:
   mode:
     noAuth:
@@ -67,7 +67,7 @@ definition:
 
 ```yaml title="An AuthConfig for JWT mode:"
 kind: AuthConfig
-version: v3
+version: v4
 definition:
   mode:
     jwt:
@@ -94,7 +94,7 @@ definition:
 
 ```yaml title="An AuthConfig for Webhook mode:"
 kind: AuthConfig
-version: v3
+version: v4
 definition:
   mode:
     webhook:


### PR DESCRIPTION
## Description 📝

This PR adds docs for multiple auth mode support introduced in `AuthConfig` v4.

- Updated the occurrences of AuthConfig v3 to AuthConfig v4
- Added a docs page on multiple auth mode

## Quick Links 🚀

 <!-- Links to the relevant place(s) in the CloudFlare Pages build. Wait for CF comment for link. -->

Multiple Auth Mode page: https://paritosh-auth-config-v4.promptql-docs.pages.dev/auth/multiple-auth-modes/

## Assertion Tests 🤖

<!-- Add assertions between the comments below to have ChatGPT check the quality of your docs contribution (Diff) and 
how well it integrates with existing docs. E.g., A user should be able to easily understand how to make a simple 
query. -->

<!-- For more info, see the Action's docs in the marketplace: https://github.com/marketplace/actions/docs-assertion-tester#usage -->

<!-- DX:Assertion-start -->
<!-- DX:Assertion-end -->