### PR TITLE
Fix: Feedback component

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -77,7 +77,7 @@ const config: Config = {
         return DOCS_SERVER_URLS[mode ?? 'development'];
       }
     })(),
-    hasuraVersion: 3,
+    hasuraVersion: "promptql",
     DEV_TOKEN: process.env.DEV_TOKEN,
     openReplayIngestPoint: 'https://analytics-openreplay.hasura-app.io/ingest',
     openReplayProjectKey: 'x5WnKn7RdPjizi93Vp5I',

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -14,14 +14,14 @@ const DOCS_SERVER_ROOT_URLS = {
 
 const DOCS_SERVER_URLS = {
   development: `http://${DOCS_SERVER_ROOT_URLS.development}`,
-  production: `https://${DOCS_SERVER_ROOT_URLS.production}`,
-  staging: `https://${DOCS_SERVER_ROOT_URLS.staging}`,
+  production: `https://${DOCS_SERVER_ROOT_URLS.production}/docs-services/docs-server`,
+  staging: `https://${DOCS_SERVER_ROOT_URLS.staging}/docs-services/docs-server`,
 };
 
 const BOT_ROUTES = {
   development: `ws://${DOCS_SERVER_ROOT_URLS.development}/bot/query`,
-  production: `wss://${DOCS_SERVER_ROOT_URLS.production}/docs-services/docs-server/bot/query`,
-  staging: `wss://${DOCS_SERVER_ROOT_URLS.staging}/docs-services/docs-server/bot/query`,
+  production: `wss://${DOCS_SERVER_ROOT_URLS.production}/bot/query`,
+  staging: `wss://${DOCS_SERVER_ROOT_URLS.staging}/bot/query`,
 };
 
 const config: Config = {

--- a/src/components/Feedback/Feedback.tsx
+++ b/src/components/Feedback/Feedback.tsx
@@ -55,7 +55,8 @@ export const Feedback = () => {
 
       // { pageTitle, pageUrl, score, userFeedback, version, docsUserId }
 
-      const storedUserID = localStorage.getItem('hasuraDocsUserID') as string | 'null';
+      const storedUserID = localStorage.getItem('hasuraDocsUserID') as string | 'null';      
+      const destinationUrl = docsServerURL + '/feedback/public-new-feedback';
 
       const raw = JSON.stringify({
         score: rating,
@@ -73,20 +74,16 @@ export const Feedback = () => {
         redirect: 'follow' as RequestRedirect,
       };
 
-      fetch(docsServerURL + '/docs-services/docs-server/feedback/public-new-feedback', requestOptions)
-        .then(response => response.text())
-        .catch(error => console.error('error', error));
+      
+      fetch(destinationUrl, requestOptions)
+        .then(response => {
+          console.log('Feedback submission status:', response.ok ? 'Success' : 'Failed');
+          return response.text();
+        })
+        .catch(error => {
+          console.error('Feedback submission failed:', error);
+        });
     };
-
-    // if (!window.location.hostname.includes('hasura.io')) {
-    //   alert(
-    //     'Hey! We like that you like our docs and chose to use them 🎉\n\nHowever, you might want to remove the feedback component or modify the route you hit, lest you want us reading what people think of your site ✌️'
-    //   );
-    //   setRating(null);
-    //   setNotes(null);
-    //   setIsSubmitSuccess(true);
-    //   return;
-    // }
 
     sendData()
       .then(() => {

--- a/src/components/Feedback/Feedback.tsx
+++ b/src/components/Feedback/Feedback.tsx
@@ -73,7 +73,7 @@ export const Feedback = () => {
         redirect: 'follow' as RequestRedirect,
       };
 
-      fetch(docsServerURL + '/feedback/public-new-feedback?', requestOptions)
+      fetch(docsServerURL + '/docs-services/docs-server/feedback/public-new-feedback', requestOptions)
         .then(response => response.text())
         .catch(error => console.error('error', error));
     };


### PR DESCRIPTION
## Description 📝

Fixes feedback component by modifying the endpoint.

Currently, the concatenated URL for the fetch here is 
```
https://website-api.hasura.io/feedback/public-new-feedback?
```

Which returns a `404`. The service actually lives at:
```
https://website-api.hasura.io/docs-services/docs-server/feedback/public-new-feedback
```

I've made the modification in this fetch because I'm not 100% sure where else `docsServerURL` is used and don't want to cause disruptions to other components.

If this is accurate, it will need to be ported to `hasura/ddn-docs`.
