### PR TITLE
Docs: Add how-to-talk section

### DIFF
--- a/docs/automation.mdx
+++ b/docs/automation.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1.6
+sidebar_position: 1.7
 sidebar_label: Automation
 description:
   "Learn how to build automated workflows and processes with PromptQL for reliable, repeatable business tasks."

--- a/docs/decision-making.mdx
+++ b/docs/decision-making.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1.5
+sidebar_position: 1.6
 sidebar_label: Decision Making
 description: "Learn how you can use PrompQL for accurate AI in your decision-making processes."
 keywords:

--- a/docs/how-to-talk-to-promptql.mdx
+++ b/docs/how-to-talk-to-promptql.mdx
@@ -1,0 +1,92 @@
+---
+sidebar_position: 1.5
+sidebar_label: How to talk to PromptQL
+description: "Learn how to talk with your data via PromptQL."
+keywords:
+  - promptql
+  - accurate
+  - reliable
+  - how to
+toc_max_heading_level: 4
+---
+
+import Thumbnail from "@site/src/components/Thumbnail";
+
+# How to Talk to PromptQL
+
+## Introduction
+
+Talking to PromptQL is like onboarding a new teammate. It starts with limited knowledge—your Day-0 analyst, engineer, or
+ops assistant—and learns quickly through the questions you ask and the feedback you provide. The more you interact with
+it, the sharper and more context-aware it becomes. Your conversations aren't just about getting answers—they’re also
+shaping how PromptQL thinks about your business, your data, and your language.
+
+## Do's
+
+PromptQL works best when you treat it like a collaborator. Ask specific questions in natural language. There's no need
+to speak in SQL or use exact technical phrases—just describe what you’re curious about.
+
+Examples:
+
+```plaintext
+Compare signups this quarter to last.
+Show me churn by region.
+Break this down by customer type.
+```
+
+It helps to add context—especially for company-specific terms, business rules, or timeframes. PromptQL will do its best
+to infer meaning, but your clarification speeds things up and improves accuracy.
+
+As you go, don’t hold back feedback. If an answer is off, say so. Corrections make it smarter. You can say:
+
+```plaintext
+That’s not what I meant.
+Can you explain how you got this?
+Try grouping it by year instead.
+Our fiscal year starts in February.
+```
+
+The more you interact, the better PromptQL gets at understanding your definitions, your patterns, and your expectations.
+It remembers what you correct. It learns how you ask.
+
+You can also ask for visualizations, request alternate views of the same data, or specify how you'd like results
+returned:
+
+```plaintext
+Show a chart of the trend.
+Group by location and limit to the top 10.
+```
+
+If you're unsure about terminology, just ask. PromptQL can define terms or explain metrics—it’s built to clarify, not
+confuse.
+
+## Don'ts
+
+Don’t expect one-shot perfection in the beginning. PromptQL thrives in back-and-forth exchanges. It doesn't retain prior
+conversation context unless you reference it, so always restate key details when continuing a line of inquiry or use an
+artifact to start a new chat.
+
+Avoid assuming it can access anything outside of your connected schema. It can’t pull in external files, ping APIs, or
+generate real-world updates from news or financial markets...unless you've added this functionality!
+
+You _should_ use niche or complex domain terms—just be ready to explain them the first time. This helps PromptQL learn
+your vocabulary and makes future conversations smoother. If it gets something wrong:
+
+```plaintext
+That’s not what “churn risk” means for us.
+In our case, “premium” refers to the paid tier only.
+```
+
+This is how PromptQL builds context over time, adapting to your business.
+
+## Next Steps
+
+The best way to get started is to ask something simple but real. Start with a metric you track regularly, or recreate an
+analysis you've done manually before. From there, PromptQL will learn your expectations, surface useful patterns, and
+help you turn those insights into reliable, repeatable workflows.
+
+We recommend picking up with [our overview of PromptQL's capabilities](#) but, if you're eager, jump in to one of these
+use cases:
+
+- [Making decisions](/decision-making.mdx)
+- [Automating tasks](/automation.mdx)


### PR DESCRIPTION
## Description 📝

Adds a how-to-talk to PromptQL section.

This is primarily based off work with the ACT folks and from being embedded with them in conversations to end users. This section will expand, but for now, it covers a very quick read that we can provide as collateral to end users who are first exploring the product.

## Quick Links 🚀

[How to Talk to PromptQL](https://add-what-can-pql-do.promptql-docs.pages.dev/how-to-talk-to-promptql/)