### PR TITLE
Docs: Create best practices documentation for promptql metadata

### DIFF
--- a/docs/metadata/guides/_category_.json
+++ b/docs/metadata/guides/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Guides",
-  "position": 6
+  "position": 7
 }

--- a/docs/metadata/index.mdx
+++ b/docs/metadata/index.mdx
@@ -51,3 +51,14 @@ important ones which form the backbone of your application are:
 - [Permissions](/metadata/permissions.mdx) which protect data
 
 We will cover each of these in more detail in the following sections.
+
+:::tip Descriptions help PromptQL
+
+Each of the metadata objects we'll examine in this section have a `description` field. Some of the objects have
+sub-objects which—in turn—can also have descriptions. If you have specific information which will aid PromptQL's
+understanding of a table or a column, add the information to the **object's** metadata using the `description` field.
+
+If you have more general information that will affect the way in which your entire set of connected data is framed,
+check out [how to use system instructions](/metadata/system-instructions.mdx).
+
+:::

--- a/docs/metadata/system-instructions.mdx
+++ b/docs/metadata/system-instructions.mdx
@@ -8,7 +8,6 @@ keywords:
   - project
   - promptql-config
   - config
-toc_max_heading_level: 4
 ---
 
 # System Instructions
@@ -16,38 +15,111 @@ toc_max_heading_level: 4
 ## Introduction
 
 Custom system instructions provide flexibility to fine-tune your PromptQL experience. This configuration allows you to
-tailor the application's behavior to your specific needs. They act as a guide for the model, shaping how it interprets
-questions and crafts responses.
+tailor the application's behavior to your specific needs. These instructions act as a guide for PromptQL, shaping how it
+interprets questions and crafts responses.
 
-**While powerful, use this feature judiciously to maintain optimal performance.**
+:::warning System Instructions shape behavior
 
-Consider this example where we set the system instructions using the `promptql-config.hml` file:
+As outlined below, system instructions shape the _behavior_ of a PromptQL application.
 
-```yaml
+However, through connecting data sources and writing your own custom business logic, you're actively providing new tools
+which PromptQL can use. While context in the form of system instructions is helpful, you can explain with greater
+detail—and with much tighter scope—what each tools does using metadata descriptions.
+
+Learn more about the available metadata objects [here](/metadata/index.mdx).
+
+:::
+
+## How to write system instructions
+
+### Example
+
+Consider this example where we set the system instructions for a GTM-focused PromptQL application.
+
+```yaml title="globals/metadata/promptql-config.hml"
 kind: PromptQlConfig
 version: v2
 definition:
   llm:
     provider: hasura
     systemInstructions: |
+
       You are an AI assistant that helps go-to-market teams make data-driven decisions.
-      You have access to data from Salesforce (opportunities, accounts, leads), Clari (forecast categories, pipeline movement), and Postgres (custom product and revenue data). 
-      Use this data to answer questions about sales performance, forecast accuracy, pipeline health, rep activity, and account trends. Prioritize clarity, brevity, and business relevance in your answers.
-      If a question is ambiguous, ask for clarification.
+
+      You have access to:
+      - Salesforce (opportunities, accounts, leads)
+      - Clari (forecast categories, pipeline movement)
+      - Postgres (custom product and revenue data)
+
+      Use this data to answer questions about:
+      - Sales performance (e.g. win rate, top reps)
+      - Forecast accuracy (e.g. projected vs actual)
+      - Pipeline health (e.g. stalled deals, pipeline coverage)
+      - Rep activity (e.g. activity count, call volume)
+      - Account trends (e.g. expansion opportunities, churn risk)
+
+      When inserting new sales records, use the function:
+      insert_revenue(product_id UUID, amount numeric, period text)
+
+      Example usage:
+      insert_revenue('123e4567-e89b-12d3-a456-426614174000', 4500.00, '2024-Q4')
+
+      Prioritize clarity, brevity, and business relevance in your answers.
+
+      If the question is ambiguous or missing key context (e.g. time range, owner name, stage), ask for clarification before proceeding.
+
+      Do not speculate. Stick to facts available in the data.
+
+      Output results in simple, easy-to-read text. Use bullet points, summaries, and key metrics where helpful. Avoid verbose explanations.
+
+      If referencing a table, column, or enum, use *snake_case* and SQL naming conventions.
 ```
 
-:::info Configuring system instructions on cloud builds
+This example demonstrates how to guide PromptQL effectively using best practices. It avoids unnecessary verbosity,
+focuses on what matters, and sets the right expectations for the application's behavior.
 
-The steps above will set the system instructions for projects during local development. To set the system instructions
-for cloud deployments, navigate to your `Settings » PromptQL` and update the `System Instructions` field.
+### Clear scope and purpose
 
-:::
+The instruction clearly defines the assistant's role:
 
-## How to write system instructions
+- **Audience:** Go-to-market teams
+- **Purpose:** Answer questions using real sales and revenue data
+- **Data sources:** Salesforce, Clari, and a custom Postgres database
 
-## What belongs in metadata?
+This helps the model stay on track and understand the boundaries of its role.
 
-## Best practices
+### Helpful context, not redundancy
+
+Rather than repeating obvious schema facts (e.g., “This column stores city names”), the system instruction provides:
+
+- Common question types (e.g., forecast accuracy, pipeline health)
+- Real-world examples of each category
+- Situations where the model should ask for clarification
+
+This context improves the quality of model outputs and helps it better understand ambiguous queries.
+
+### Global guidance is in the right place
+
+Important global behaviors are captured here instead of scattered across metadata:
+
+- Stick to **facts**—don’t speculate
+- Ask for clarification if details are missing
+- Use **snake_case** and SQL naming conventions
+- Prioritize **clarity and brevity** in outputs
+
+System instructions are the best place to capture these global rules.
+
+### Structured, prescriptive, and precise
+
+The instructions are written in a simple, structured format:
+
+- Bulleted lists for data sources and use cases
+- Clear formatting expectations; markdown is acceptable
+- No filler or LLM-generated fluff
+
+This makes the guidance both human-readable and model-optimized.
+
+### Guidelines
 
 When writing system instructions, your goal is to **narrow the model's focus** and **reduce ambiguity**. Here are some
 guidelines.
@@ -62,19 +134,13 @@ guidelines.
 - **Provide code patterns or examples:** You can include sample Python functions, formulas, or logic patterns to guide
   how the model generates its own code. These are not backend functions to call, but templates for the LLM to adapt and
   build from.
+- **Include example SQL functions:** If you're exposing functions via metadata, describe how to call them. Include
+  argument names, data types, and a sample use case. For example:
+
+  > Use the `insert_revenue(product_id: UUID, amount: numeric, period: text)` function when answering questions
+  > involving new sales data. This records revenue per product for a specific period.
+
 - **Anticipate ambiguity:** If the model might face unclear inputs, instruct it on when and how to ask for
   clarification.
 - **Set limits if needed:** If certain topics, behaviors, or types of output should be avoided, explicitly mention them.
 - **Test and iterate:** Start simple, evaluate outputs, and refine your instructions based on observed model behavior.
-
-:::info System instructions shape behavior
-
-As outlined above, system instructions shape the behavior of a PromptQL application.
-
-However, through connecting data sources and writing your own custom business logic, you're actively providing new tools
-which PromptQL can use. While context in the form of system instructions is helpful, you can explain with greater
-detail—and with much tighter scope—what each tools does using metadata descriptions.
-
-Learn more [here](/metadata/index.mdx).
-
-:::

--- a/docs/metadata/system-instructions.mdx
+++ b/docs/metadata/system-instructions.mdx
@@ -86,7 +86,7 @@ The instruction clearly defines the assistant's role:
 - **Purpose:** Answer questions using real sales and revenue data
 - **Data sources:** Salesforce, Clari, and a custom Postgres database
 
-This helps the model stay on track and understand the boundaries of its role.
+This helps the application stay on track and understand the boundaries of its role.
 
 ### Helpful context, not redundancy
 
@@ -94,9 +94,9 @@ Rather than repeating obvious schema facts (e.g., “This column stores city nam
 
 - Common question types (e.g., forecast accuracy, pipeline health)
 - Real-world examples of each category
-- Situations where the model should ask for clarification
+- Situations where the application should ask for clarification
 
-This context improves the quality of model outputs and helps it better understand ambiguous queries.
+This context improves the quality of the application's outputs and helps it better understand ambiguous queries.
 
 ### Global guidance is in the right place
 
@@ -121,18 +121,18 @@ This makes the guidance both human-readable and model-optimized.
 
 ### Guidelines
 
-When writing system instructions, your goal is to **narrow the model's focus** and **reduce ambiguity**. Here are some
+When writing system instructions, your goal is to **narrow PromptQL's focus** and **reduce ambiguity**. Here are some
 guidelines.
 
-- **Be clear and concise:** The model performs better when instructions are direct and avoid unnecessary complexity.
-- **Define the role and audience:** Tell the model who it is (e.g., a sales analyst, a support bot) and who it is
+- **Be clear and concise:** PromptQL performs better when instructions are direct and avoid unnecessary complexity.
+- **Define the role and audience:** Tell the agent who it is (e.g., a sales analyst, a support bot) and who it is
   helping.
-- **Specify sources of knowledge:** Mention any data sources, systems, or domains the model should rely on when
+- **Specify sources of knowledge:** Mention any data sources, systems, or domains PromptQL should rely on when
   answering.
 - **Encourage appropriate behavior:** Highlight priorities like brevity, clarity, formality, creativity, or
   error-handling.
 - **Provide code patterns or examples:** You can include sample Python functions, formulas, or logic patterns to guide
-  how the model generates its own code. These are not backend functions to call, but templates for the LLM to adapt and
+  how PromptQL generates its own code. These are not backend functions to call, but templates for the LLM to adapt and
   build from.
 - **Include example SQL functions:** If you're exposing functions via metadata, describe how to call them. Include
   argument names, data types, and a sample use case. For example:
@@ -140,7 +140,7 @@ guidelines.
   > Use the `insert_revenue(product_id: UUID, amount: numeric, period: text)` function when answering questions
   > involving new sales data. This records revenue per product for a specific period.
 
-- **Anticipate ambiguity:** If the model might face unclear inputs, instruct it on when and how to ask for
+- **Anticipate ambiguity:** If the application might face unclear inputs, instruct it on when and how to ask for
   clarification.
 - **Set limits if needed:** If certain topics, behaviors, or types of output should be avoided, explicitly mention them.
-- **Test and iterate:** Start simple, evaluate outputs, and refine your instructions based on observed model behavior.
+- **Test and iterate:** Start simple, evaluate outputs, and refine your instructions based on observed behavior.

--- a/docs/metadata/system-instructions.mdx
+++ b/docs/metadata/system-instructions.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 6
 sidebar_label: System Instructions
 description: Learn how to configure your PromptQL application via metadata.
 keywords:
@@ -15,27 +15,25 @@ toc_max_heading_level: 4
 
 ## Introduction
 
-Custom system instructions provide flexibility to fine-tune your PromptQL experience. This optional configuration allows
-you to tailor the application's behavior to your specific needs. They act as a guide for the model, shaping how it
-interprets questions and crafts responses.
+Custom system instructions provide flexibility to fine-tune your PromptQL experience. This configuration allows you to
+tailor the application's behavior to your specific needs. They act as a guide for the model, shaping how it interprets
+questions and crafts responses.
 
 **While powerful, use this feature judiciously to maintain optimal performance.**
 
-```yaml title="Consider this example where we set the system instructions using the promptql-config.hml file:"
+Consider this example where we set the system instructions using the `promptql-config.hml` file:
+
+```yaml
 kind: PromptQlConfig
 version: v2
 definition:
   llm:
     provider: hasura
-  systemInstructions: |
-
-    You are an AI assistant that helps go-to-market teams make data-driven decisions.
-
-    You have access to data from Salesforce (opportunities, accounts, leads), Clari (forecast categories, pipeline movement), and Postgres (custom product and revenue data). 
-
-    Use this data to answer questions about sales performance, forecast accuracy, pipeline health, rep activity, and account trends. Prioritize clarity, brevity, and business relevance in your answers.
-
-    If a question is ambiguous, ask for clarification.
+    systemInstructions: |
+      You are an AI assistant that helps go-to-market teams make data-driven decisions.
+      You have access to data from Salesforce (opportunities, accounts, leads), Clari (forecast categories, pipeline movement), and Postgres (custom product and revenue data). 
+      Use this data to answer questions about sales performance, forecast accuracy, pipeline health, rep activity, and account trends. Prioritize clarity, brevity, and business relevance in your answers.
+      If a question is ambiguous, ask for clarification.
 ```
 
 :::info Configuring system instructions on cloud builds
@@ -44,6 +42,10 @@ The steps above will set the system instructions for projects during local devel
 for cloud deployments, navigate to your `Settings » PromptQL` and update the `System Instructions` field.
 
 :::
+
+## How to write system instructions
+
+## What belongs in metadata?
 
 ## Best practices
 

--- a/docs/project-configuration/promptql-config/index.mdx
+++ b/docs/project-configuration/promptql-config/index.mdx
@@ -63,4 +63,4 @@ With `promptql-config.hml` file, you can:
 ## Next steps
 
 - [Check out how to configure your LLM of choice](/project-configuration/promptql-config/providers.mdx).
-- [Learn how to improve performance by using system instructions](/project-configuration/promptql-config/system-instructions.mdx).
+- [Learn how to improve performance by using system instructions](/metadata/system-instructions.mdx).

--- a/docs/project-configuration/promptql-config/providers.mdx
+++ b/docs/project-configuration/promptql-config/providers.mdx
@@ -147,8 +147,8 @@ PromptQL program generation.
 - The `model` key is **not supported** when using the `hasura` provider.
 - The value for a `model` key is always in the dialect of the provider's API.
 - If `ai_primitives_llm` is not defined, it defaults to the provider specified in the `llm` configuration.
-- [`system_instructions` are optional](/project-configuration/promptql-config/system-instructions.mdx) but recommended
-  to customize the behavior of your LLM.
+- [`system_instructions` are optional](/metadata/system-instructions.mdx) but recommended to customize the behavior of
+  your LLM.
 
 :::tip Set your API key as an environment variable
 


### PR DESCRIPTION
## Description 📝

Moves `system-instructions.mdx` to the `/metadata` directory after the relevant metadata objects. In subsequent commits, we'll build context on this page to make it clear what belongs in system instructions and what doesn't (i.e., what should be in relevant metadata objects' pages).

Adds details for system instructions by stealing what makes sense in the ACT folks' Confluence.

## Quick Links 🚀

[System Instructions](https://robdominguez-doc-2957-create.promptql-docs.pages.dev/metadata/system-instructions/)