### PR TITLE
Chore: Fix issues with feedback components visibilty

### DIFF
--- a/src/components/Feedback/styles.module.css
+++ b/src/components/Feedback/styles.module.css
@@ -68,7 +68,7 @@ html[data-theme='dark'] .feedback {
 
 .form h3 {
   font-size: 1.25rem;
-  color: var(--primary-neutral-200);
+  color: var(--heading-color);
   margin-bottom: 0.5rem;
 }
 
@@ -85,11 +85,11 @@ html[data-theme='dark'] .feedback {
   font-size: 0.875rem;
   padding: 0.75rem;
   line-height: 1.5rem;
-  color: var(--primary-neutral-200);
+  color: var(--heading-color);
   margin-top: 1rem;
   box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.2);
   width: 100%;
-  background-color: var(--primary-dark);
+  background-color: var(--main-bg-color);
 }
 
 .form input::placeholder,
@@ -132,7 +132,7 @@ html[data-theme='dark'] .feedback {
 
 .textAreaLabel p {
   margin-bottom: 0.5rem;
-  color: var(--primary-neutral-300);
+  color: var(--body-text-color);
 }
 
 .buttonDisabled {
@@ -146,13 +146,9 @@ html[data-theme='dark'] .feedback {
 
 html[data-theme='dark'] .form input,
 html[data-theme='dark'] .form textarea {
-  border: 1px solid var(--header-border-bottom);
-}
-
-html[data-theme='dark'] .feedback input,
-html[data-theme='dark'] .feedback textarea {
-  background-color: var(--color-gray-74);
-  color: white;
+  border: 1px solid var(--primary-neutral-600);
+  background-color: var(--primary-neutral-800);
+  color: var(--primary-neutral-200);
 }
 
 .successMessage {
@@ -166,7 +162,7 @@ html[data-theme='dark'] .feedback textarea {
 
 .successMessage p {
   margin-bottom: 0.5rem !important;
-  color: var(--primary-neutral-300);
+  color: var(--body-text-color);
 }
 
 .successMessage a {


### PR DESCRIPTION
## Description 📝

• Fixed low-contrast text colors in feedback component that were making content difficult to read
• Resolved dark background input fields appearing in light mode
• Improved dark mode textarea visibility by adding proper contrast

Previously, the feedback section was using hardcoded neutral colors that created accessibility issues:

```css
.form h3 {
  color: var(--primary-neutral-200); /* Too light */
}

.form input,
.form textarea {
  color: var(--primary-neutral-200);
  background-color: var(--primary-dark); /* Black bg in light mode */
}

.textAreaLabel p {
  color: var(--primary-neutral-300); /* Very light gray */
}
```

**Light Mode**
<img width="766" height="608" alt="image" src="https://github.com/user-attachments/assets/400222e9-f2d7-49af-9b8d-d17627e3af87" />

**Dark Mode**
<img width="766" height="608" alt="image" src="https://github.com/user-attachments/assets/79f9a45c-da0c-4f90-ace9-dbd3d33a19b9" />


Now we're using semantic color variables that adapt properly to both themes:

```css
.form h3 {
  color: var(--heading-color); /* Theme-aware heading color */
}

.form input,
.form textarea {
  color: var(--heading-color);
  background-color: var(--main-bg-color); /* White in light, dark in dark */
}

html[data-theme='dark'] .form input,
html[data-theme='dark'] .form textarea {
  border: 1px solid var(--primary-neutral-600);
  background-color: var(--primary-neutral-800);
  color: var(--primary-neutral-200);
}
```

**Light Mode**
<img width="766" height="608" alt="image" src="https://github.com/user-attachments/assets/92a78715-e380-4b71-8d2a-e5ff683caef5" />

**Dark Mode**
<img width="766" height="608" alt="image" src="https://github.com/user-attachments/assets/955c9e18-5663-40a2-b507-b45209d5126d" />

The changes ensure proper contrast ratios for accessibility compliance while maintaining visual hierarchy. Text inputs now have appropriate backgrounds in both light and dark modes, and all text elements use semantic color variables that provide sufficient contrast against their backgrounds. You know, like they should.
