### PR TITLE
Add option for llms-full.txt URL

### DIFF
--- a/src/components/CopyLlmText/index.tsx
+++ b/src/components/CopyLlmText/index.tsx
@@ -4,6 +4,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 export default function CopyLLM() {
   const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
+  const [urlStatus, setUrlStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
   const [isOpen, setIsOpen] = useState(false);
   const [fileContent, setFileContent] = useState<string | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -131,6 +132,23 @@ export default function CopyLLM() {
     }
   }
 
+  async function handleCopyUrl() {
+    const fullUrl = 'https://promptql.io/docs/llms-full.txt';
+    try {
+      await copyToClipboard(fullUrl);
+      setUrlStatus('success');
+      setTimeout(() => {
+        setUrlStatus('idle');
+      }, 2000);
+    } catch (err) {
+      console.error(err);
+      setUrlStatus('error');
+      setTimeout(() => {
+        setUrlStatus('idle');
+      }, 2000);
+    }
+  }
+
   return (
     <div className={styles.container} ref={containerRef}>
       <button className={styles.ellipsisButton} onClick={() => setIsOpen(!isOpen)} aria-label="Document actions">
@@ -154,6 +172,13 @@ export default function CopyLLM() {
           </button>
           <button className={styles.dropdownItem} onClick={handleDownload}>
             Download docs content
+          </button>
+          <button className={styles.dropdownItem} onClick={handleCopyUrl} disabled={status === 'loading' || urlStatus === 'loading'}>
+            {urlStatus === 'success'
+              ? '✅ URL Copied!'
+              : urlStatus === 'error'
+              ? 'Failed to copy URL'
+              : 'Copy URL to docs file'}
           </button>
         </div>
       )}


### PR DESCRIPTION
## Description 📝

Previously, the `CopyLLM` component only offered two actions: copying the full docs content to clipboard and downloading it as a file. Users had no way to quickly share the direct URL to the compiled docs file.

````tsx path=src/components/CopyLlmText/index.tsx mode=EXCERPT
// Before: Only copy and download options
<button className={styles.dropdownItem} onClick={handleCopy}>
  Copy all docs content to clipboard for use in LLM prompts
</button>
<button className={styles.dropdownItem} onClick={handleDownload}>
  Download docs content
</button>
````

Now, there's a third option that copies the direct URL (`https://promptql.io/docs/llms-full.txt`) to the clipboard, complete with its own loading and success states.

````tsx path=src/components/CopyLlmText/index.tsx mode=EXCERPT
// After: Added URL copy functionality
<button className={styles.dropdownItem} onClick={handleCopyUrl} disabled={status === 'loading' || urlStatus === 'loading'}>
  {urlStatus === 'success'
    ? '✅ URL Copied!'
    : urlStatus === 'error'
    ? 'Failed to copy URL'
    : 'Copy URL to docs file'}
</button>
````

This enhancement makes it trivial for users to share the compiled documentation URL with others or reference it in external tools, rather than having to navigate to the file location manually. The implementation follows the same state management pattern as the existing copy functionality, ensuring consistent UX across all three actions.
