### PR TITLE
Chore: Replace arch ERDs with mermaid

### DIFF
--- a/docs/private-ddn/architecture/byoc.mdx
+++ b/docs/private-ddn/architecture/byoc.mdx
@@ -37,7 +37,56 @@ requests. Even if the Control Plane becomes unavailable, the Data Plane continue
 
 :::
 
-<Thumbnail src="/img/deployment/private_ddn_byoc.png" alt="Private DDN Architecture BYOC " />
+```mermaid
+flowchart TD
+  %% Layout hints
+  %% Top-to-bottom: PromptQL Infra (top), Customer Infra (bottom)
+
+  %% ===== PromptQL Infrastructure =====
+  subgraph pqlInfra[PromptQL Infrastructure]
+    direction TB
+    subgraph control[Control Plane]
+      cp_api[API Explorer]
+      cp_obs[Observability]
+      cp_builds[Builds & Deployments]
+      cp_auth[Auth/SSO<br/>Access Control]
+    end
+  end
+
+  %% ===== Customer Infrastructure =====
+  subgraph custInfra[Customer Infrastructure]
+    direction TB
+
+    %% --- Data Plane ---
+    subgraph dp[Data Plane]
+      pql_engine[[PromptQL]]
+      dp_conn[Connectors]
+    end
+
+    %% --- Sources ---
+    subgraph src[Sources]
+      src_db[Databases]
+      src_api[Other APIs]
+      src_conn[Connectors]
+    end
+  end
+
+  %% ===== External User =====
+  user(Users)
+
+  %% ===== Relationships =====
+  user -- "PromptQL APIs" --> pql_engine
+
+  %% Data plane -> sources
+  pql_engine --> dp_conn
+  dp_conn --> src
+
+  %% Control plane to data plane (management/ops)
+  cp_api -.-> pql_engine
+  cp_obs -.-> pql_engine
+  cp_builds -.-> pql_engine
+  cp_auth -.-> pql_engine
+```
 
 ## Data Flow and security
 

--- a/docs/private-ddn/architecture/dedicated.mdx
+++ b/docs/private-ddn/architecture/dedicated.mdx
@@ -31,7 +31,56 @@ Gateway, or any other equivalent connectivity option offered by the cloud provid
 
 Please reach out to us if you need support for another cloud or configuration that is not mentioned here.
 
-<Thumbnail src="/img/deployment/private_ddn_hasura_hosted.png" alt="Private DDN Architecture Hasura Hosted" />
+```mermaid
+flowchart TD
+  %% Layout hints
+  %% Top-to-bottom: PromptQL Infra with Dedicated VPC (top), Customer Infra (bottom)
+
+  %% ===== PromptQL Infrastructure =====
+  subgraph pqlInfra[PromptQL Infrastructure]
+    direction TB
+    subgraph dedicatedVPC[Dedicated VPC]
+      direction TB
+      subgraph control[Control Plane]
+        cp_api[API Explorer]
+        cp_obs[Observability]
+        cp_builds[Builds & Deployments]
+        cp_auth[Auth/SSO<br/>Access Control]
+      end
+
+      subgraph dp[Data Plane]
+        pql_engine[[PromptQL]]
+        dp_conn[Connectors]
+      end
+    end
+  end
+
+  %% ===== Customer Infrastructure =====
+  subgraph custInfra[Customer Infrastructure]
+    direction TB
+    subgraph src[Sources]
+      src_db[Databases]
+      src_api[Other APIs]
+      src_conn[Connectors]
+    end
+  end
+
+  %% ===== External User =====
+  user(Users)
+
+  %% ===== Relationships =====
+  user -- "PromptQL APIs" --> pql_engine
+
+  %% Data plane -> sources (with private network annotation)
+  pql_engine --> dp_conn
+  dp_conn -- "Traffic over private network" --> src
+
+  %% Control plane to data plane (management/ops)
+  cp_api -.-> pql_engine
+  cp_obs -.-> pql_engine
+  cp_builds -.-> pql_engine
+  cp_auth -.-> pql_engine
+```
 
 ## Get started
 


### PR DESCRIPTION
## Description 📝

- Replaced static architecture diagrams with interactive Mermaid flowcharts for BYOC and Dedicated deployment modes
- Enhanced documentation accessibility for DocsQL by making diagrams machine-readable
- Maintained visual consistency across both deployment architectures

Previously, our Private DDN architecture documentation relied on static PNG images that were invisible to our DocsQL service:

````mdx path=docs/private-ddn/architecture/byoc.mdx mode=EXCERPT
<Thumbnail src="/img/deployment/private_ddn_byoc.png" alt="Private DDN Architecture BYOC " />
````

Now, we've converted these into structured Mermaid diagrams that DocsQL can parse and understand:

### BYOC

```mermaid
flowchart TD
  %% Layout hints
  %% Top-to-bottom: PromptQL Infra (top), Customer Infra (bottom)

  %% ===== PromptQL Infrastructure =====
  subgraph pqlInfra[PromptQL Infrastructure]
    direction TB
    subgraph control[Control Plane]
      cp_api[API Explorer]
      cp_obs[Observability]
      cp_builds[Builds & Deployments]
      cp_auth[Auth/SSO<br/>Access Control]
    end
  end

  %% ===== Customer Infrastructure =====
  subgraph custInfra[Customer Infrastructure]
    direction TB

    %% --- Data Plane ---
    subgraph dp[Data Plane]
      pql_engine[[PromptQL]]
      dp_conn[Connectors]
    end

    %% --- Sources ---
    subgraph src[Sources]
      src_db[Databases]
      src_api[Other APIs]
      src_conn[Connectors]
    end
  end

  %% ===== External User =====
  user(Users)

  %% ===== Relationships =====
  user -- "PromptQL APIs" --> pql_engine

  %% Data plane -> sources
  pql_engine --> dp_conn
  dp_conn --> src

  %% Control plane to data plane (management/ops)
  cp_api -.-> pql_engine
  cp_obs -.-> pql_engine
  cp_builds -.-> pql_engine
  cp_auth -.-> pql_engine
```

### Dedicated

```mermaid
flowchart TD
  %% Layout hints
  %% Top-to-bottom: PromptQL Infra with Dedicated VPC (top), Customer Infra (bottom)

  %% ===== PromptQL Infrastructure =====
  subgraph pqlInfra[PromptQL Infrastructure]
    direction TB
    subgraph dedicatedVPC[Dedicated VPC]
      direction TB
      subgraph control[Control Plane]
        cp_api[API Explorer]
        cp_obs[Observability]
        cp_builds[Builds & Deployments]
        cp_auth[Auth/SSO<br/>Access Control]
      end

      subgraph dp[Data Plane]
        pql_engine[[PromptQL]]
        dp_conn[Connectors]
      end
    end
  end

  %% ===== Customer Infrastructure =====
  subgraph custInfra[Customer Infrastructure]
    direction TB
    subgraph src[Sources]
      src_db[Databases]
      src_api[Other APIs]
      src_conn[Connectors]
    end
  end

  %% ===== External User =====
  user(Users)

  %% ===== Relationships =====
  user -- "PromptQL APIs" --> pql_engine

  %% Data plane -> sources (with private network annotation)
  pql_engine --> dp_conn
  dp_conn -- "Traffic over private network" --> src

  %% Control plane to data plane (management/ops)
  cp_api -.-> pql_engine
  cp_obs -.-> pql_engine
  cp_builds -.-> pql_engine
  cp_auth -.-> pql_engine
```

This change transforms our architecture documentation from visual-only content into semantic, queryable information. DocsQL can now understand the relationships between Control Planes, Data Planes, and customer infrastructure, making it significantly more effective at answering architecture-related questions. The diagrams maintain the same visual clarity for human readers while becoming accessible to our AI documentation assistant.