### PR TITLE
Docs: Add admonition for permission requirements

### DIFF
--- a/docs/_quickstart_template.mdx
+++ b/docs/_quickstart_template.mdx
@@ -1,5 +1,13 @@
 import Thumbnail from "@site/src/components/Thumbnail";
 
+:::info Project Creation Requirements
+
+To create a project, you'll need both a [Hasura Cloud account](https://cloud.hasura.io/signup) and have been granted
+permission to create projects via our AI Catalyst Team. If you haven't been in touch, you can reach out
+[here](https://promptql.io/book-demo) to get help.
+
+:::
+
 ### Step 1. Authenticate your CLI
 
 ```ddn title="Before you can create a new Hasura DDN project, you need to authenticate your CLI:"

--- a/docs/how-to-build-with-promptql/_boilerplateInit.mdx
+++ b/docs/how-to-build-with-promptql/_boilerplateInit.mdx
@@ -1,3 +1,11 @@
+:::info Project Creation Requirements
+
+To create a project, you'll need both a [Hasura Cloud account](https://cloud.hasura.io/signup) and have been granted
+permission to create projects via our AI Catalyst Team. If you haven't been in touch, you can reach out
+[here](https://promptql.io/book-demo) to get help.
+
+:::
+
 ### Step 1. Authenticate your CLI
 
 ```ddn title="Before you can create a new PromptQL project, you need to authenticate your CLI:"

--- a/docs/how-to-build-with-promptql/with-api-endpoints.mdx
+++ b/docs/how-to-build-with-promptql/with-api-endpoints.mdx
@@ -16,6 +16,14 @@ import Prereqs from "@site/docs/_prereqs.mdx";
 
 # With API Endpoints
 
+:::info Project Creation Requirements
+
+To create a project, you'll need both a [Hasura Cloud account](https://cloud.hasura.io/signup) and have been granted
+permission to create projects via our AI Catalyst Team. If you haven't been in touch, you can reach out
+[here](https://promptql.io/book-demo) to get help.
+
+:::
+
 We can connect PromptQL to API endpoints to query them directly.
 
 Sometimes bulk loading data from API services might be overkill. In such cases, connecting to API endpoints directly is

--- a/docs/how-to-build-with-promptql/with-apis-with-bulk-data.mdx
+++ b/docs/how-to-build-with-promptql/with-apis-with-bulk-data.mdx
@@ -17,6 +17,14 @@ import Prereqs from "@site/docs/_prereqs.mdx";
 
 # With Bulk API Data
 
+:::info Project Creation Requirements
+
+To create a project, you'll need both a [Hasura Cloud account](https://cloud.hasura.io/signup) and have been granted
+permission to create projects via our AI Catalyst Team. If you haven't been in touch, you can reach out
+[here](https://promptql.io/book-demo) to get help.
+
+:::
+
 In this tutorial we'll see how to connect to an API source that has some bulk data we want to bring into PromptQL.
 
 This is what we'll do:

--- a/docs/private-ddn/create-a-project-on-a-data-plane.mdx
+++ b/docs/private-ddn/create-a-project-on-a-data-plane.mdx
@@ -15,6 +15,14 @@ import Prereqs from "@site/docs/_prereqs.mdx";
 
 # Create a Project on a Data Plane
 
+:::info Project Creation Requirements
+
+To create a project, you'll need both a [Hasura Cloud account](https://cloud.hasura.io/signup) and have been granted
+permission to create projects via our AI Catalyst Team. If you haven't been in touch, you can reach out
+[here](https://promptql.io/book-demo) to get help.
+
+:::
+
 ## Introduction
 
 :::tip Important

--- a/docs/private-ddn/ddn-workspace.mdx
+++ b/docs/private-ddn/ddn-workspace.mdx
@@ -16,6 +16,14 @@ import Thumbnail from "@site/src/components/Thumbnail";
 
 # Developing with DDN Workspace
 
+:::info Project Creation Requirements
+
+To create a project, you'll need both a [Hasura Cloud account](https://cloud.hasura.io/signup) and have been granted
+permission to create projects via our AI Catalyst Team. If you haven't been in touch, you can reach out
+[here](https://promptql.io/book-demo) to get help.
+
+:::
+
 ## Introduction
 
 DDN Workspace provides a browser-based development environment for working with Private DDN, eliminating the need to

--- a/docs/project-configuration/tutorials/manage-multiple-environments.mdx
+++ b/docs/project-configuration/tutorials/manage-multiple-environments.mdx
@@ -12,6 +12,14 @@ keywords:
 
 # Manage Multiple Environments
 
+:::info Project Creation Requirements
+
+To create a project, you'll need both a [Hasura Cloud account](https://cloud.hasura.io/signup) and have been granted
+permission to create projects via our AI Catalyst Team. If you haven't been in touch, you can reach out
+[here](https://promptql.io/book-demo) to get help.
+
+:::
+
 ## Introduction
 
 Managing multiple contexts in your application allows you to replicate the functionality of traditional environments

--- a/docs/project-configuration/tutorials/work-with-multiple-repositories.mdx
+++ b/docs/project-configuration/tutorials/work-with-multiple-repositories.mdx
@@ -14,6 +14,14 @@ toc_max_heading_level: 4
 
 # Work with Multiple Repositories
 
+:::info Project Creation Requirements
+
+To create a project, you'll need both a [Hasura Cloud account](https://cloud.hasura.io/signup) and have been granted
+permission to create projects via our AI Catalyst Team. If you haven't been in touch, you can reach out
+[here](https://promptql.io/book-demo) to get help.
+
+:::
+
 ## Introduction
 
 Managing multiple repositories lets you distribute development across independent subgraphs located in separate

--- a/docs/project-configuration/tutorials/work-with-multiple-subgraphs.mdx
+++ b/docs/project-configuration/tutorials/work-with-multiple-subgraphs.mdx
@@ -12,6 +12,14 @@ keywords:
 
 # Work with Multiple Subgraphs
 
+:::info Project Creation Requirements
+
+To create a project, you'll need both a [Hasura Cloud account](https://cloud.hasura.io/signup) and have been granted
+permission to create projects via our AI Catalyst Team. If you haven't been in touch, you can reach out
+[here](https://promptql.io/book-demo) to get help.
+
+:::
+
 ## Introduction
 
 Learn how to manage multiple subgraphs to streamline team ownership, enforce clear data boundaries, and scale your


### PR DESCRIPTION
## Description 📝

Previously, project creation requirements were inconsistently documented across our tutorial pages. Some had the info block, others referenced it indirectly, and the messaging varied slightly between pages.

````mdx path=docs/how-to-build-with-promptql/with-api-endpoints.mdx mode=EXCERPT
:::info Project Creation Requirements

To create a project, you'll need both a [Hasura Cloud account](https://cloud.hasura.io/signup) and have been granted
permission to create projects via our AI Catalyst Team. If you haven't been in touch, you can reach out
[here](https://promptql.io/book-demo) to get help.

:::
````

Now every tutorial that involves project creation gets the same clear, actionable requirements block right at the top. This eliminates confusion about prerequisites and ensures users know exactly what they need before diving into any tutorial.

The change affects 9 documentation files across PromptQL tutorials, Private DDN guides, and project configuration docs. Each now opens with identical messaging about needing a Hasura Cloud account and AI Catalyst Team permissions, creating a consistent onboarding experience regardless of which tutorial users encounter first.
